### PR TITLE
Bug Fix for Creating Personal Schedule

### DIFF
--- a/frontend/src/main/components/Quarters/SingleQuarterDropdown.js
+++ b/frontend/src/main/components/Quarters/SingleQuarterDropdown.js
@@ -20,11 +20,11 @@ function SingleQuarterDropdown({
   onChange = null,
   label = "Quarter",
 }) {
-  // Stryker disable all : not sure how to test/mock local storage
+  
   if (localStorage.getItem("PersonalScheduleForm-quarter") == null) {
     localStorage.setItem("PersonalScheduleForm-quarter", quarters[0].yyyyq);
   }
-  // Stryker enable all
+  
   const localSearchQuarter = localStorage.getItem(controlId);
 
   const [quarterState, setQuarterState] = useState(

--- a/frontend/src/main/components/Quarters/SingleQuarterDropdown.js
+++ b/frontend/src/main/components/Quarters/SingleQuarterDropdown.js
@@ -20,7 +20,7 @@ function SingleQuarterDropdown({
   onChange = null,
   label = "Quarter",
 }) {
-  if (localStorage.length == 0) {
+  if (localStorage.getItem("PersonalScheduleForm-quarter") == null) {
     localStorage.setItem(controlId, quarters[0].yyyyq);
   }
   const localSearchQuarter = localStorage.getItem(controlId);

--- a/frontend/src/main/components/Quarters/SingleQuarterDropdown.js
+++ b/frontend/src/main/components/Quarters/SingleQuarterDropdown.js
@@ -21,7 +21,7 @@ function SingleQuarterDropdown({
   label = "Quarter",
 }) {
   if (localStorage.getItem("PersonalScheduleForm-quarter") == null) {
-    localStorage.setItem(controlId, quarters[0].yyyyq);
+    localStorage.setItem("PersonalScheduleForm-quarter", quarters[0].yyyyq);
   }
   const localSearchQuarter = localStorage.getItem(controlId);
 

--- a/frontend/src/main/components/Quarters/SingleQuarterDropdown.js
+++ b/frontend/src/main/components/Quarters/SingleQuarterDropdown.js
@@ -20,9 +20,11 @@ function SingleQuarterDropdown({
   onChange = null,
   label = "Quarter",
 }) {
+  // Stryker disable all : not sure how to test/mock local storage
   if (localStorage.getItem("PersonalScheduleForm-quarter") == null) {
     localStorage.setItem("PersonalScheduleForm-quarter", quarters[0].yyyyq);
   }
+  // Stryker enable all
   const localSearchQuarter = localStorage.getItem(controlId);
 
   const [quarterState, setQuarterState] = useState(

--- a/frontend/src/main/components/Quarters/SingleQuarterDropdown.js
+++ b/frontend/src/main/components/Quarters/SingleQuarterDropdown.js
@@ -20,11 +20,10 @@ function SingleQuarterDropdown({
   onChange = null,
   label = "Quarter",
 }) {
-  
   if (localStorage.getItem("PersonalScheduleForm-quarter") == null) {
     localStorage.setItem("PersonalScheduleForm-quarter", quarters[0].yyyyq);
   }
-  
+
   const localSearchQuarter = localStorage.getItem(controlId);
 
   const [quarterState, setQuarterState] = useState(

--- a/frontend/src/main/components/Quarters/SingleQuarterDropdown.js
+++ b/frontend/src/main/components/Quarters/SingleQuarterDropdown.js
@@ -20,6 +20,9 @@ function SingleQuarterDropdown({
   onChange = null,
   label = "Quarter",
 }) {
+  if (localStorage.length == 0) {
+    localStorage.setItem(controlId, quarters[0].yyyyq);
+  }
   const localSearchQuarter = localStorage.getItem(controlId);
 
   const [quarterState, setQuarterState] = useState(

--- a/frontend/src/tests/components/Quarters/SingleQuarterDropdown.test.js
+++ b/frontend/src/tests/components/Quarters/SingleQuarterDropdown.test.js
@@ -167,6 +167,12 @@ describe("SingleQuarterSelector tests", () => {
       />,
     );
 
-    await waitFor(() => expect(useState).toBeCalledWith("20201"), expect(localStorage.setItem).toBeCalledWith("PersonalScheduleForm-quarter", "20201"));
+    await waitFor(
+      () => expect(useState).toBeCalledWith("20201"),
+      expect(localStorage.setItem).toBeCalledWith(
+        "PersonalScheduleForm-quarter",
+        "20201",
+      ),
+    );
   });
 });

--- a/frontend/src/tests/components/Quarters/SingleQuarterDropdown.test.js
+++ b/frontend/src/tests/components/Quarters/SingleQuarterDropdown.test.js
@@ -167,6 +167,6 @@ describe("SingleQuarterSelector tests", () => {
       />,
     );
 
-    await waitFor(() => expect(useState).toBeCalledWith("20201"), expect(localStorage.setItem).toHaveBeenCalled());
+    await waitFor(() => expect(useState).toBeCalledWith("20201"), expect(localStorage.setItem).toBeCalledWith("PersonalScheduleForm-quarter", "20201"));
   });
 });

--- a/frontend/src/tests/components/Quarters/SingleQuarterDropdown.test.js
+++ b/frontend/src/tests/components/Quarters/SingleQuarterDropdown.test.js
@@ -148,4 +148,25 @@ describe("SingleQuarterSelector tests", () => {
 
     await waitFor(() => expect(useState).toBeCalledWith("20201"));
   });
+
+  test("localStorage has a value when rendered", async () => {
+    const getItemSpy = jest.spyOn(Storage.prototype, "getItem");
+    getItemSpy.mockImplementation(() => null);
+
+    const setQuarterStateSpy = jest.fn();
+    useState.mockImplementation((x) => [x, setQuarterStateSpy]);
+
+    jest.spyOn(Storage.prototype, "setItem");
+
+    render(
+      <SingleQuarterDropdown
+        quarters={quarterRange("20201", "20224")}
+        quarter={quarter}
+        setQuarter={setQuarter}
+        controlId="sqd1"
+      />,
+    );
+
+    await waitFor(() => expect(useState).toBeCalledWith("20201"), expect(localStorage.setItem).toHaveBeenCalled());
+  });
 });


### PR DESCRIPTION
In this PR, we implement a bug fix for creating personal schedules. 

To test that it is working properly, navigate to this [page](https://proj-courses-awesomebob35-dev.dokku-09.cs.ucsb.edu) and login.

Open the developer console with "Ctrl + Shift + J". Navigate to application by clicking the ">>" symbol in the top row. Under local storage, ensure that the key "PersonalScheduleForm-quarter" does not exist, and if it does, delete it. 

![image](https://github.com/ucsb-cs156-f23/proj-courses-f23-7pm-1/assets/97574232/92f2c817-2cbb-4cac-aaf2-b8dedbdbc9f6)

Now click "Personal Schedules" in the navigation bar and click "Add Schedule". Fill out the "name" and "description" fields but do not touch the "quarter" field, It should just say W22. Create the schedule and ensure that it has been created with the right name, description, and W22 as the quarter. 

If you want to test again, repeat the steps in the developer console. Also try doing something else (like searching for courses) first before creating a new schedule. A previous fix was only working if creating a personal schedule was the first thing a user did. 

Closes #11 