### PR TITLE
Fix sections not showing up on instructor search

### DIFF
--- a/frontend/src/main/components/InstructorSearch/InstructorSearchTable.js
+++ b/frontend/src/main/components/InstructorSearch/InstructorSearchTable.js
@@ -15,13 +15,10 @@ import { Button } from "react-bootstrap";
 import InstructorSearchTableBase from "../InstructorSearchTableBase";
 
 export default function InstructorSearchTable({ sections }) {
-  // Stryker enable all
-  // Stryker disable BooleanLiteral
   const columns = [
     {
       Header: "Quarter",
       accessor: (row) => yyyyqToQyy(row.courseInfo.quarter),
-      disableGroupBy: true,
       id: "quarter",
     },
     {
@@ -33,7 +30,6 @@ export default function InstructorSearchTable({ sections }) {
     {
       Header: "Title",
       accessor: "courseInfo.title",
-      disableGroupBy: true,
     },
     {
       // Stryker disable next-line StringLiteral: this column is hidden, very hard to test
@@ -51,20 +47,17 @@ export default function InstructorSearchTable({ sections }) {
         else if (isSectionFull(row.section)) return "FULL";
         else return "OPEN";
       },
-      disableGroupBy: true,
       id: "status",
     },
     {
       Header: "Enrolled",
       accessor: (row) =>
         convertToFraction(row.section.enrolledTotal, row.section.maxEnroll),
-      disableGroupBy: true,
       id: "enrolled",
     },
     {
       Header: "Location",
       accessor: (row) => formatLocation(row.section.timeLocations),
-      disableGroupBy: true,
       id: "location",
     },
     {
@@ -76,31 +69,26 @@ export default function InstructorSearchTable({ sections }) {
     {
       Header: "Days",
       accessor: (row) => formatDays(row.section.timeLocations),
-      disableGroupBy: true,
       id: "days",
     },
     {
       Header: "Time",
       accessor: (row) => formatTime(row.section.timeLocations),
-      disableGroupBy: true,
       id: "time",
     },
     {
       Header: "Instructor",
       accessor: (row) => formatInstructors(row.section.instructors),
-      disableGroupBy: true,
       id: "instructor",
     },
     {
       Header: "Enroll Code",
       accessor: "section.enrollCode",
-      disableGroupBy: true,
     },
     {
       Header: "Info",
       accessor: (row) =>
         `/coursedetails/${row.courseInfo.quarter}/${row.section.enrollCode}`,
-      disableGroupBy: true,
       id: "info",
 
       Cell: ({ cell: { value } }) => (

--- a/frontend/src/main/components/InstructorSearch/InstructorSearchTable.js
+++ b/frontend/src/main/components/InstructorSearch/InstructorSearchTable.js
@@ -1,0 +1,124 @@
+import { yyyyqToQyy } from "main/utils/quarterUtilities.js";
+
+import {
+  convertToFraction,
+  formatDays,
+  formatInstructors,
+  formatLocation,
+  formatTime,
+  isSection,
+  isSectionCancelled,
+  isSectionClosed,
+  isSectionFull,
+} from "main/utils/sectionUtils.js";
+import { Button } from "react-bootstrap";
+import InstructorSearchTableBase from "../InstructorSearchTableBase";
+
+export default function InstructorSearchTable({ sections }) {
+  // Stryker enable all
+  // Stryker disable BooleanLiteral
+  const columns = [
+    {
+      Header: "Quarter",
+      accessor: (row) => yyyyqToQyy(row.courseInfo.quarter),
+      disableGroupBy: true,
+      id: "quarter",
+    },
+    {
+      Header: "Course ID",
+      accessor: "courseInfo.courseId",
+
+      Cell: ({ cell: { value } }) => value.substring(0, value.length - 2),
+    },
+    {
+      Header: "Title",
+      accessor: "courseInfo.title",
+      disableGroupBy: true,
+    },
+    {
+      // Stryker disable next-line StringLiteral: this column is hidden, very hard to test
+      Header: "Is Section?",
+      accessor: (row) => isSection(row.section.section),
+      // Stryker disable next-line StringLiteral: this column is hidden, very hard to test
+      id: "isSection",
+    },
+    {
+      Header: "Status",
+      accessor: (row) => {
+        if (isSectionCancelled(row.section)) return "CANCELLED";
+        else if (isSectionClosed(row.section)) return "CLOSED";
+        else if (isSectionFull(row.section)) return "FULL";
+        else return "OPEN";
+      },
+      disableGroupBy: true,
+      id: "status",
+    },
+    {
+      Header: "Enrolled",
+      accessor: (row) =>
+        convertToFraction(row.section.enrolledTotal, row.section.maxEnroll),
+      disableGroupBy: true,
+      id: "enrolled",
+    },
+    {
+      Header: "Location",
+      accessor: (row) => formatLocation(row.section.timeLocations),
+      disableGroupBy: true,
+      id: "location",
+    },
+    {
+      Header: "Section Number",
+      accessor: (row) => row.section.section,
+      // Stryker disable next-line StringLiteral: this column is hidden, very hard to test
+      id: "sectionNumber",
+    },
+    {
+      Header: "Days",
+      accessor: (row) => formatDays(row.section.timeLocations),
+      disableGroupBy: true,
+      id: "days",
+    },
+    {
+      Header: "Time",
+      accessor: (row) => formatTime(row.section.timeLocations),
+      disableGroupBy: true,
+      id: "time",
+    },
+    {
+      Header: "Instructor",
+      accessor: (row) => formatInstructors(row.section.instructors),
+      disableGroupBy: true,
+      id: "instructor",
+    },
+    {
+      Header: "Enroll Code",
+      accessor: "section.enrollCode",
+      disableGroupBy: true,
+    },
+    {
+      Header: "Info",
+      accessor: (row) =>
+        `/coursedetails/${row.courseInfo.quarter}/${row.section.enrollCode}`,
+      disableGroupBy: true,
+      id: "info",
+
+      Cell: ({ cell: { value } }) => (
+        <Button variant="outline-dark" size="sm" href={value}>
+          ⓘ
+        </Button>
+      ),
+    },
+  ];
+
+  const testid = "InstructorSearchTable";
+
+  const columnsToDisplay = columns;
+
+  return (
+    <InstructorSearchTableBase
+      data={sections}
+      columns={columnsToDisplay}
+      testid={testid}
+    />
+  );
+}

--- a/frontend/src/main/components/InstructorSearch/InstructorSearchTable.js
+++ b/frontend/src/main/components/InstructorSearch/InstructorSearchTable.js
@@ -38,6 +38,7 @@ export default function InstructorSearchTable({ sections }) {
     {
       // Stryker disable next-line StringLiteral: this column is hidden, very hard to test
       Header: "Is Section?",
+      // Stryker disable next-line all: this column is hidden, very hard to test
       accessor: (row) => isSection(row.section.section),
       // Stryker disable next-line StringLiteral: this column is hidden, very hard to test
       id: "isSection",

--- a/frontend/src/main/components/InstructorSearchTableBase.js
+++ b/frontend/src/main/components/InstructorSearchTableBase.js
@@ -13,7 +13,7 @@ export default function InstructorSearchTableBase({
     useTable(
       {
         initialState: {
-          hiddenColumns: ["isSection"]
+          hiddenColumns: ["isSection"],
         },
         columns,
         data,

--- a/frontend/src/main/components/InstructorSearchTableBase.js
+++ b/frontend/src/main/components/InstructorSearchTableBase.js
@@ -2,7 +2,6 @@ import React, { Fragment } from "react";
 import { useTable, useExpanded } from "react-table";
 import { Table } from "react-bootstrap";
 
-// Stryker disable StringLiteral, ArrayDeclaration
 export default function InstructorSearchTableBase({
   columns,
   data,
@@ -28,41 +27,33 @@ export default function InstructorSearchTableBase({
         {headerGroups.map((headerGroup) => (
           <tr {...headerGroup.getHeaderGroupProps()}>
             {headerGroup.headers.map((column) => (
-              <th
-                {...column.getHeaderProps()}
-                data-testid={`${testid}-header-${column.id}`}
-              >
-                {column.render("Header")}
-              </th>
+              <th {...column.getHeaderProps()}>{column.render("Header")}</th>
             ))}
           </tr>
         ))}
       </thead>
       <tbody {...getTableBodyProps()} key="tbody">
-        {rows.map((row, i) => {
+        {rows.map((row) => {
           prepareRow(row);
           return (
-            <Fragment key={`row-${i}`}>
-              <tr {...row.getRowProps()}>
-                {row.cells.map((cell, _index) => {
-                  return (
-                    <td
-                      {...cell.getCellProps()}
-                      data-testid={`${testid}-cell-row-${cell.row.index}-col-${cell.column.id}`}
-                      // Stryker disable next-line ObjectLiteral
-                      style={{
-                        background: "#34859b",
-                        color: "#effcf4",
-                        fontWeight: "bold",
-                      }}
-                    >
-                      {cell.render("Cell")}
-                      <></>
-                    </td>
-                  );
-                })}
-              </tr>
-            </Fragment>
+            <tr {...row.getRowProps()}>
+              {row.cells.map((cell, _index) => {
+                return (
+                  <td
+                    {...cell.getCellProps()}
+                    data-testid={`${testid}-cell-row-${cell.row.index}-col-${cell.column.id}`}
+                    style={{
+                      background: "#34859b",
+                      color: "#effcf4",
+                      fontWeight: "bold",
+                    }}
+                  >
+                    {cell.render("Cell")}
+                    <></>
+                  </td>
+                );
+              })}
+            </tr>
           );
         })}
       </tbody>

--- a/frontend/src/main/components/InstructorSearchTableBase.js
+++ b/frontend/src/main/components/InstructorSearchTableBase.js
@@ -12,6 +12,7 @@ export default function InstructorSearchTableBase({
   const { getTableProps, getTableBodyProps, headerGroups, rows, prepareRow } =
     useTable(
       {
+        // Stryker disable next-line all
         initialState: {
           hiddenColumns: ["isSection"],
         },

--- a/frontend/src/main/components/InstructorSearchTableBase.js
+++ b/frontend/src/main/components/InstructorSearchTableBase.js
@@ -1,0 +1,67 @@
+import React, { Fragment } from "react";
+import { useTable, useExpanded } from "react-table";
+import { Table } from "react-bootstrap";
+
+// Stryker disable StringLiteral, ArrayDeclaration
+export default function InstructorSearchTableBase({
+  columns,
+  data,
+  testid = "testid",
+}) {
+  // Stryker disable next-line ObjectLiteral
+  const { getTableProps, getTableBodyProps, headerGroups, rows, prepareRow } =
+    useTable(
+      {
+        columns,
+        data,
+      },
+      useExpanded,
+    );
+
+  return (
+    <Table {...getTableProps()} striped bordered hover>
+      <thead key="thead">
+        {headerGroups.map((headerGroup) => (
+          <tr {...headerGroup.getHeaderGroupProps()}>
+            {headerGroup.headers.map((column) => (
+              <th
+                {...column.getHeaderProps()}
+                data-testid={`${testid}-header-${column.id}`}
+              >
+                {column.render("Header")}
+              </th>
+            ))}
+          </tr>
+        ))}
+      </thead>
+      <tbody {...getTableBodyProps()} key="tbody">
+        {rows.map((row, i) => {
+          prepareRow(row);
+          return (
+            <Fragment key={`row-${i}`}>
+              <tr {...row.getRowProps()}>
+                {row.cells.map((cell, _index) => {
+                  return (
+                    <td
+                      {...cell.getCellProps()}
+                      data-testid={`${testid}-cell-row-${cell.row.index}-col-${cell.column.id}`}
+                      // Stryker disable next-line ObjectLiteral
+                      style={{
+                        background: "#34859b",
+                        color: "#effcf4",
+                        fontWeight: "bold",
+                      }}
+                    >
+                      {cell.render("Cell")}
+                      <></>
+                    </td>
+                  );
+                })}
+              </tr>
+            </Fragment>
+          );
+        })}
+      </tbody>
+    </Table>
+  );
+}

--- a/frontend/src/main/components/InstructorSearchTableBase.js
+++ b/frontend/src/main/components/InstructorSearchTableBase.js
@@ -12,6 +12,9 @@ export default function InstructorSearchTableBase({
   const { getTableProps, getTableBodyProps, headerGroups, rows, prepareRow } =
     useTable(
       {
+        initialState: {
+          hiddenColumns: ["isSection"]
+        },
         columns,
         data,
       },

--- a/frontend/src/main/pages/CourseOverTime/CourseOverTimeInstructorIndexPage.js
+++ b/frontend/src/main/pages/CourseOverTime/CourseOverTimeInstructorIndexPage.js
@@ -2,7 +2,7 @@ import { useState } from "react";
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
 import CourseOverTimeInstructorSearchForm from "main/components/BasicCourseSearch/CourseOverTimeInstructorSearchForm";
 import { useBackendMutation } from "main/utils/useBackend";
-import SectionsTable from "main/components/Sections/SectionsTable";
+import InstructorSearchTable from "main/components/InstructorSearch/InstructorSearchTable";
 
 export default function CourseOverTimeInstructorIndexPage() {
   // Stryker disable next-line all : Can't test state because hook is internal
@@ -40,7 +40,7 @@ export default function CourseOverTimeInstructorIndexPage() {
         <CourseOverTimeInstructorSearchForm
           fetchJSON={fetchCourseOverTimeJSON}
         />
-        <SectionsTable sections={courseJSON} />
+        <InstructorSearchTable sections={courseJSON} />
       </div>
     </BasicLayout>
   );

--- a/frontend/src/tests/components/InstructorSearch/InstructorSearchTable.test.js
+++ b/frontend/src/tests/components/InstructorSearch/InstructorSearchTable.test.js
@@ -1,0 +1,281 @@
+import { render, screen } from "@testing-library/react";
+import { fiveSections, gigaSections } from "fixtures/sectionFixtures";
+import InstructorSearchTable from "main/components/InstructorSearch/InstructorSearchTable";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+
+const mockedNavigate = jest.fn();
+
+jest.mock("react-router-dom", () => ({
+  ...jest.requireActual("react-router-dom"),
+  useNavigate: () => mockedNavigate,
+}));
+
+describe("Section tests", () => {
+  const queryClient = new QueryClient();
+
+  test("renders without crashing for empty table", () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <InstructorSearchTable sections={[]} />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+  });
+
+  test("Has the expected cell values when expanded", () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <InstructorSearchTable sections={fiveSections} />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    const expectedHeaders = [
+      "Quarter",
+      "Course ID",
+      "Title",
+      "Status",
+      "Enrolled",
+      "Location",
+      "Days",
+      "Time",
+      "Instructor",
+      "Enroll Code",
+      "Info",
+    ];
+    const expectedFields = [
+      "quarter",
+      "courseInfo.courseId",
+      "courseInfo.title",
+      "status",
+      "enrolled",
+      "location",
+      "days",
+      "time",
+      "instructor",
+      "section.enrollCode",
+      "info",
+    ];
+    const testId = "InstructorSearchTable";
+
+    expectedHeaders.forEach((headerText) => {
+      const header = screen.getByText(headerText);
+      expect(header).toBeInTheDocument();
+    });
+
+    expectedFields.forEach((field) => {
+      const header = screen.getByTestId(`${testId}-cell-row-0-col-${field}`);
+      expect(header).toBeInTheDocument();
+    });
+
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-quarter`),
+    ).toHaveTextContent("W22");
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-time`),
+    ).toHaveTextContent("3:00 PM - 3:50 PM");
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-days`),
+    ).toHaveTextContent("M");
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-status`),
+    ).toHaveTextContent("OPEN");
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-enrolled`),
+    ).toHaveTextContent("84/100");
+    expect(
+      screen.getByTestId(`${testId}-cell-row-2-col-location`),
+    ).toHaveTextContent("HFH 1124");
+    expect(
+      screen.getByTestId(`${testId}-cell-row-2-col-instructor`),
+    ).toHaveTextContent("YUNG A S");
+    expect(
+      screen.getByTestId(`${testId}-cell-row-2-col-info`).children[0],
+    ).toHaveTextContent("ⓘ");
+  });
+
+  test("Has the expected column headers and content", async () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <InstructorSearchTable sections={fiveSections} />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    const expectedHeaders = [
+      "Quarter",
+      "Course ID",
+      "Title",
+      "Status",
+      "Enrolled",
+      "Location",
+      "Days",
+      "Time",
+      "Instructor",
+      "Enroll Code",
+
+      "Section Number",
+
+      "Info",
+    ];
+    const expectedFields = [
+      "quarter",
+      "courseInfo.courseId",
+      "courseInfo.title",
+      "status",
+      "enrolled",
+      "location",
+      "days",
+      "time",
+      "instructor",
+      "section.enrollCode",
+      "sectionNumber",
+      "info",
+    ];
+    const testId = "InstructorSearchTable";
+
+    expectedHeaders.forEach((headerText) => {
+      const header = screen.getByText(headerText);
+      expect(header).toBeInTheDocument();
+    });
+
+    expectedFields.forEach((field) => {
+      const header = screen.getByTestId(`${testId}-cell-row-0-col-${field}`);
+      expect(header).toBeInTheDocument();
+    });
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-courseInfo.courseId`),
+    ).toHaveTextContent("ECE 1A");
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-courseInfo.title`),
+    ).toHaveTextContent("COMP ENGR SEMINAR");
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-quarter`),
+    ).toHaveTextContent("W22");
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-sectionNumber`),
+    ).toHaveTextContent("0100");
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-time`),
+    ).toHaveTextContent("3:00 PM - 3:50 PM");
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-days`),
+    ).toHaveTextContent("M");
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-status`),
+    ).toHaveTextContent("OPEN");
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-enrolled`),
+    ).toHaveTextContent("84/100");
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-location`),
+    ).toHaveTextContent("BUCHN 1930");
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-instructor`),
+    ).toHaveTextContent("WANG L C");
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-section.enrollCode`),
+    ).toHaveTextContent("12583");
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-info`).children[0],
+    ).toHaveTextContent("ⓘ");
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-info`).children[0].href,
+    ).toMatch(/\/coursedetails\/20221\/12583$/);
+  });
+
+  test("Correctly groups separate lectures of the same class", async () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <InstructorSearchTable sections={gigaSections} />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    const testId = "InstructorSearchTable";
+
+    expect(
+      screen.getByTestId(`${testId}-cell-row-1-col-courseInfo.courseId`),
+    ).toHaveTextContent("MATH 3A");
+    expect(
+      screen.getByTestId(`${testId}-cell-row-2-col-courseInfo.courseId`),
+    ).toHaveTextContent("MATH 3A");
+
+    expect(
+      screen.getByTestId(`${testId}-cell-row-1-col-courseInfo.courseId`),
+    ).toHaveTextContent("MATH 3A");
+  });
+
+  test("First dropdown is different than last dropdown", () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <InstructorSearchTable sections={fiveSections} />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    const testId = "InstructorSearchTable";
+
+    expect(
+      screen.getByTestId(`${testId}-cell-row-1-col-enrolled`),
+    ).toHaveTextContent("84/80");
+    expect(
+      screen.getByTestId(`${testId}-cell-row-2-col-enrolled`),
+    ).toHaveTextContent("21/21");
+  });
+
+  test("Sections have appropriate status columns", () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <InstructorSearchTable sections={fiveSections} />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    const testId = "InstructorSearchTable";
+
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-status`),
+    ).toHaveTextContent("OPEN");
+    expect(
+      screen.getByTestId(`${testId}-cell-row-1-col-status`),
+    ).toHaveTextContent("CLOSED");
+    expect(
+      screen.getByTestId(`${testId}-cell-row-2-col-status`),
+    ).toHaveTextContent("FULL");
+    expect(
+      screen.getByTestId(`${testId}-cell-row-3-col-status`),
+    ).toHaveTextContent("CANCELLED");
+  });
+  test("Sections have appropriate section number columns", () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <InstructorSearchTable sections={fiveSections} />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    const testId = "InstructorSearchTable";
+
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-status`),
+    ).toHaveTextContent("OPEN");
+    expect(
+      screen.getByTestId(`${testId}-cell-row-1-col-status`),
+    ).toHaveTextContent("CLOSED");
+    expect(
+      screen.getByTestId(`${testId}-cell-row-2-col-status`),
+    ).toHaveTextContent("FULL");
+    expect(
+      screen.getByTestId(`${testId}-cell-row-3-col-status`),
+    ).toHaveTextContent("CANCELLED");
+  });
+});

--- a/frontend/src/tests/components/InstructorSearchTableBase.test.js
+++ b/frontend/src/tests/components/InstructorSearchTableBase.test.js
@@ -142,6 +142,10 @@ describe("InstructorSearchTableBase tests", () => {
       />,
     );
 
+    expect(screen.queryByText("Is Section?")).not.toBeInTheDocument();
+    expect(
+      screen.getByTestId("testid-cell-row-1-col-courseInfo.courseId"),
+    ).toBeInTheDocument();
     expect(
       screen.getByTestId("testid-cell-row-0-col-courseInfo.courseId"),
     ).toHaveAttribute(

--- a/frontend/src/tests/components/InstructorSearchTableBase.test.js
+++ b/frontend/src/tests/components/InstructorSearchTableBase.test.js
@@ -1,0 +1,152 @@
+import { render, screen } from "@testing-library/react";
+import {
+  fiveSections,
+  gigaSections,
+  oneLectureSectionWithNoDiscussion,
+} from "fixtures/sectionFixtures";
+import InstructorSearchTableBase from "main/components/InstructorSearchTableBase";
+import { yyyyqToQyy } from "main/utils/quarterUtilities.js";
+import {
+  convertToFraction,
+  formatDays,
+  formatInstructors,
+  formatLocation,
+  formatTime,
+  isSection,
+} from "main/utils/sectionUtils.js";
+
+describe("InstructorSearchTableBase tests", () => {
+  function getFirstVal(values) {
+    return values[0];
+  }
+
+  const columns = [
+    {
+      Header: "Quarter",
+      accessor: (row) => yyyyqToQyy(row.courseInfo.quarter),
+      disableGroupBy: true,
+      id: "quarter",
+
+      aggregate: getFirstVal,
+      Aggregated: ({ cell: { value } }) => `${value}`,
+    },
+    {
+      Header: "Course ID",
+      accessor: "courseInfo.courseId",
+
+      Cell: ({ cell: { value } }) => value.substring(0, value.length - 2),
+    },
+    {
+      Header: "Title",
+      accessor: "courseInfo.title",
+      disableGroupBy: true,
+
+      aggregate: getFirstVal,
+      Aggregated: ({ cell: { value } }) => `${value}`,
+    },
+    {
+      // Stryker disable next-line StringLiteral: this column is hidden, very hard to test
+      Header: "Is Section?",
+      accessor: (row) => isSection(row.section.section),
+      // Stryker disable next-line StringLiteral: this column is hidden, very hard to test
+      id: "isSection",
+    },
+    {
+      Header: "Enrolled",
+      accessor: (row) =>
+        convertToFraction(row.section.enrolledTotal, row.section.maxEnroll),
+      disableGroupBy: true,
+      id: "enrolled",
+
+      aggregate: getFirstVal,
+      Aggregated: ({ cell: { value } }) => `${value}`,
+    },
+    {
+      Header: "Location",
+      accessor: (row) => formatLocation(row.section.timeLocations),
+      disableGroupBy: true,
+      id: "location",
+
+      aggregate: getFirstVal,
+      Aggregated: ({ cell: { value } }) => `${value}`,
+    },
+    {
+      Header: "Days",
+      accessor: (row) => formatDays(row.section.timeLocations),
+      disableGroupBy: true,
+      id: "days",
+
+      aggregate: getFirstVal,
+      Aggregated: ({ cell: { value } }) => `${value}`,
+    },
+    {
+      Header: "Time",
+      accessor: (row) => formatTime(row.section.timeLocations),
+      disableGroupBy: true,
+      id: "time",
+
+      aggregate: getFirstVal,
+      Aggregated: ({ cell: { value } }) => `${value}`,
+    },
+    {
+      Header: "Instructor",
+      accessor: (row) => formatInstructors(row.section.instructors),
+      disableGroupBy: true,
+      id: "instructor",
+
+      aggregate: getFirstVal,
+      Aggregated: ({ cell: { value } }) => `${value}`,
+    },
+    {
+      Header: "Enroll Code",
+      accessor: "section.enrollCode",
+      disableGroupBy: true,
+
+      aggregate: getFirstVal,
+      Aggregated: ({ cell: { value } }) => `${value}`,
+    },
+  ];
+
+  test("renders an empty table without crashing", () => {
+    render(
+      <InstructorSearchTableBase columns={columns} data={[]} group={false} />,
+    );
+  });
+
+  test("renders an full table without crashing", () => {
+    render(
+      <InstructorSearchTableBase
+        columns={columns}
+        data={gigaSections}
+        group={false}
+      />,
+    );
+  });
+
+  test("renders a single lecture section correctly", async () => {
+    render(
+      <InstructorSearchTableBase
+        columns={columns}
+        data={oneLectureSectionWithNoDiscussion}
+        group={false}
+      />,
+    );
+  });
+
+  test("renders five sections correctly", async () => {
+    render(
+      <InstructorSearchTableBase
+        columns={columns}
+        data={fiveSections}
+        group={false}
+      />,
+    );
+
+    expect(
+      screen.getByTestId("testid-cell-row-0-col-courseInfo.courseId"),
+    ).toHaveAttribute(
+      "style",
+      "background: rgb(52, 133, 155); color: rgb(239, 252, 244); font-weight: bold;",
+    );
+  });
+});


### PR DESCRIPTION
Fixed search by instructor functionality by removing the expandable "+" sign, as proposed by issue #9. This was done by creating another table without the grouping. "+" sign is present in other searches, such as building search.

Dokku deployment:
https://proj-courses-rdoumeth.dokku-09.cs.ucsb.edu/courseovertime/instructorsearch

<img width="1511" alt="image" src="https://github.com/ucsb-cs156-f23/proj-courses-f23-7pm-1/assets/86987744/975a29c8-8dd8-476a-ba4a-bd1d42067f27">

Closes #9 