### PR TITLE
Add Course Details button to course search results

### DIFF
--- a/frontend/src/main/components/Sections/SectionsOverTimeTable.js
+++ b/frontend/src/main/components/Sections/SectionsOverTimeTable.js
@@ -12,6 +12,7 @@ import {
   isSectionClosed,
   isSectionFull,
 } from "main/utils/sectionUtils.js";
+import { Button } from "react-bootstrap";
 
 function getFirstVal(values) {
   return values[0];

--- a/frontend/src/main/components/Sections/SectionsOverTimeTable.js
+++ b/frontend/src/main/components/Sections/SectionsOverTimeTable.js
@@ -131,6 +131,7 @@ export default function SectionsOverTimeTable({ sections }) {
       Header: "Info",
       accessor: (row) => `/course/details/${row.courseInfo.quarter}/${row.section.enrollCode}`,
       disableGroupBy: true,
+      id: "info",
 
       aggregate: getFirstVal,
       Cell: ({ cell: { value } }) => (
@@ -139,7 +140,7 @@ export default function SectionsOverTimeTable({ sections }) {
           size="sm"
           href={value}
         >
-          {"ⓘ"}
+          ⓘ
         </Button>
       ),
       Aggregated: ({ cell: { value } }) => (
@@ -148,7 +149,7 @@ export default function SectionsOverTimeTable({ sections }) {
           size="sm"
           href={value}
         >
-          {"ⓘ"}
+          ⓘ
         </Button>
       )
     },

--- a/frontend/src/main/components/Sections/SectionsOverTimeTable.js
+++ b/frontend/src/main/components/Sections/SectionsOverTimeTable.js
@@ -126,6 +126,21 @@ export default function SectionsOverTimeTable({ sections }) {
       aggregate: getFirstVal,
       Aggregated: ({ cell: { value } }) => `${value}`,
     },
+    {
+      Header: "Info",
+      accessor: (row) => row,
+      disableGroupBy: true,
+
+      aggregate: getFirstVal,
+      Aggregated: ({ cell: { value } }) => (
+        <Button
+          size="sm"
+          href={`/course/details/${value.courseInfo.quarter}/${value.section.enrollCode}`}
+        >
+          {"ⓘ"}
+        </Button>
+      )
+    },
   ];
 
   const testid = "SectionsOverTimeTable";

--- a/frontend/src/main/components/Sections/SectionsOverTimeTable.js
+++ b/frontend/src/main/components/Sections/SectionsOverTimeTable.js
@@ -129,14 +129,24 @@ export default function SectionsOverTimeTable({ sections }) {
     },
     {
       Header: "Info",
-      accessor: (row) => row,
+      accessor: (row) => `/course/details/${row.courseInfo.quarter}/${row.section.enrollCode}`,
       disableGroupBy: true,
 
       aggregate: getFirstVal,
+      Cell: ({ cell: { value } }) => (
+        <Button
+          variant="outline-dark"
+          size="sm"
+          href={value}
+        >
+          {"ⓘ"}
+        </Button>
+      ),
       Aggregated: ({ cell: { value } }) => (
         <Button
+          variant="outline-light"
           size="sm"
-          href={`/course/details/${value.courseInfo.quarter}/${value.section.enrollCode}`}
+          href={value}
         >
           {"ⓘ"}
         </Button>

--- a/frontend/src/main/components/Sections/SectionsOverTimeTable.js
+++ b/frontend/src/main/components/Sections/SectionsOverTimeTable.js
@@ -130,7 +130,7 @@ export default function SectionsOverTimeTable({ sections }) {
     {
       Header: "Info",
       accessor: (row) =>
-        `/course/details/${row.courseInfo.quarter}/${row.section.enrollCode}`,
+        `/coursedetails/${row.courseInfo.quarter}/${row.section.enrollCode}`,
       disableGroupBy: true,
       id: "info",
 

--- a/frontend/src/main/components/Sections/SectionsOverTimeTable.js
+++ b/frontend/src/main/components/Sections/SectionsOverTimeTable.js
@@ -129,29 +129,22 @@ export default function SectionsOverTimeTable({ sections }) {
     },
     {
       Header: "Info",
-      accessor: (row) => `/course/details/${row.courseInfo.quarter}/${row.section.enrollCode}`,
+      accessor: (row) =>
+        `/course/details/${row.courseInfo.quarter}/${row.section.enrollCode}`,
       disableGroupBy: true,
       id: "info",
 
       aggregate: getFirstVal,
       Cell: ({ cell: { value } }) => (
-        <Button
-          variant="outline-dark"
-          size="sm"
-          href={value}
-        >
+        <Button variant="outline-dark" size="sm" href={value}>
           ⓘ
         </Button>
       ),
       Aggregated: ({ cell: { value } }) => (
-        <Button
-          variant="outline-light"
-          size="sm"
-          href={value}
-        >
+        <Button variant="outline-light" size="sm" href={value}>
           ⓘ
         </Button>
-      )
+      ),
     },
   ];
 

--- a/frontend/src/main/components/Sections/SectionsTable.js
+++ b/frontend/src/main/components/Sections/SectionsTable.js
@@ -12,6 +12,7 @@ import {
   isSectionClosed,
   isSectionFull,
 } from "main/utils/sectionUtils.js";
+import { Button } from "react-bootstrap";
 
 function getFirstVal(values) {
   return values[0];
@@ -118,6 +119,21 @@ export default function SectionsTable({ sections }) {
 
       aggregate: getFirstVal,
       Aggregated: ({ cell: { value } }) => `${value}`,
+    },
+    {
+      Header: "Info",
+      accessor: (row) => row,
+      disableGroupBy: true,
+
+      aggregate: getFirstVal,
+      Aggregated: ({ cell: { value } }) => (
+        <Button
+          size="sm"
+          href={`/course/details/${value.courseInfo.quarter}/${value.section.enrollCode}`}
+        >
+          {"ⓘ"}
+        </Button>
+      )
     },
   ];
 

--- a/frontend/src/main/components/Sections/SectionsTable.js
+++ b/frontend/src/main/components/Sections/SectionsTable.js
@@ -124,6 +124,7 @@ export default function SectionsTable({ sections }) {
       Header: "Info",
       accessor: (row) => `/course/details/${row.courseInfo.quarter}/${row.section.enrollCode}`,
       disableGroupBy: true,
+      id: "info",
 
       aggregate: getFirstVal,
       Cell: ({ cell: { value } }) => (
@@ -132,7 +133,7 @@ export default function SectionsTable({ sections }) {
           size="sm"
           href={value}
         >
-          {"ⓘ"}
+          ⓘ
         </Button>
       ),
       Aggregated: ({ cell: { value } }) => (
@@ -141,7 +142,7 @@ export default function SectionsTable({ sections }) {
           size="sm"
           href={value}
         >
-          {"ⓘ"}
+          ⓘ
         </Button>
       )
     },

--- a/frontend/src/main/components/Sections/SectionsTable.js
+++ b/frontend/src/main/components/Sections/SectionsTable.js
@@ -122,14 +122,24 @@ export default function SectionsTable({ sections }) {
     },
     {
       Header: "Info",
-      accessor: (row) => row,
+      accessor: (row) => `/course/details/${row.courseInfo.quarter}/${row.section.enrollCode}`,
       disableGroupBy: true,
 
       aggregate: getFirstVal,
+      Cell: ({ cell: { value } }) => (
+        <Button
+          variant="outline-dark"
+          size="sm"
+          href={value}
+        >
+          {"ⓘ"}
+        </Button>
+      ),
       Aggregated: ({ cell: { value } }) => (
         <Button
+          variant="outline-light"
           size="sm"
-          href={`/course/details/${value.courseInfo.quarter}/${value.section.enrollCode}`}
+          href={value}
         >
           {"ⓘ"}
         </Button>

--- a/frontend/src/main/components/Sections/SectionsTable.js
+++ b/frontend/src/main/components/Sections/SectionsTable.js
@@ -123,7 +123,7 @@ export default function SectionsTable({ sections }) {
     {
       Header: "Info",
       accessor: (row) =>
-        `/course/details/${row.courseInfo.quarter}/${row.section.enrollCode}`,
+        `/coursedetails/${row.courseInfo.quarter}/${row.section.enrollCode}`,
       disableGroupBy: true,
       id: "info",
 

--- a/frontend/src/main/components/Sections/SectionsTable.js
+++ b/frontend/src/main/components/Sections/SectionsTable.js
@@ -122,29 +122,22 @@ export default function SectionsTable({ sections }) {
     },
     {
       Header: "Info",
-      accessor: (row) => `/course/details/${row.courseInfo.quarter}/${row.section.enrollCode}`,
+      accessor: (row) =>
+        `/course/details/${row.courseInfo.quarter}/${row.section.enrollCode}`,
       disableGroupBy: true,
       id: "info",
 
       aggregate: getFirstVal,
       Cell: ({ cell: { value } }) => (
-        <Button
-          variant="outline-dark"
-          size="sm"
-          href={value}
-        >
+        <Button variant="outline-dark" size="sm" href={value}>
           ⓘ
         </Button>
       ),
       Aggregated: ({ cell: { value } }) => (
-        <Button
-          variant="outline-light"
-          size="sm"
-          href={value}
-        >
+        <Button variant="outline-light" size="sm" href={value}>
           ⓘ
         </Button>
-      )
+      ),
     },
   ];
 

--- a/frontend/src/tests/components/Sections/SectionsOverTimeTable.test.js
+++ b/frontend/src/tests/components/Sections/SectionsOverTimeTable.test.js
@@ -193,7 +193,7 @@ describe("Section tests", () => {
     ).toHaveTextContent("ⓘ");
     expect(
       screen.getByTestId(`${testId}-cell-row-0-col-info`).children[0].href,
-    ).toMatch(/\/course\/details\/20222\/08078$/);
+    ).toMatch(/\/coursedetails\/20222\/08078$/);
   });
 
   test("Correctly groups separate quarters of the same class", async () => {

--- a/frontend/src/tests/components/Sections/SectionsOverTimeTable.test.js
+++ b/frontend/src/tests/components/Sections/SectionsOverTimeTable.test.js
@@ -47,7 +47,8 @@ describe("Section tests", () => {
       "Days",
       "Time",
       "Instructor",
-      "Enroll Code",,
+      "Enroll Code",
+      ,
       "Info",
     ];
     const expectedFields = [
@@ -102,7 +103,7 @@ describe("Section tests", () => {
       screen.getByTestId(`${testId}-cell-row-5-col-instructor`),
     ).toHaveTextContent("DANESHAMOOZ J, KILGORE J D, YANG YIFAN");
     expect(
-      screen.getByTestId(`${testId}-cell-row-5-col-info`).children[0]
+      screen.getByTestId(`${testId}-cell-row-5-col-info`).children[0],
     ).toHaveTextContent("ⓘ");
     expect(
       screen.getByTestId(`${testId}-cell-row-5-col-courseInfo.courseId`),
@@ -189,10 +190,10 @@ describe("Section tests", () => {
       screen.getByTestId(`${testId}-cell-row-0-col-section.enrollCode`),
     ).toHaveTextContent("08078");
     expect(
-      screen.getByTestId(`${testId}-cell-row-0-col-info`).children[0]
+      screen.getByTestId(`${testId}-cell-row-0-col-info`).children[0],
     ).toHaveTextContent("ⓘ");
     expect(
-      screen.getByTestId(`${testId}-cell-row-0-col-info`).children[0].href
+      screen.getByTestId(`${testId}-cell-row-0-col-info`).children[0].href,
     ).toMatch(/\/course\/details\/20222\/08078$/);
   });
 

--- a/frontend/src/tests/components/Sections/SectionsOverTimeTable.test.js
+++ b/frontend/src/tests/components/Sections/SectionsOverTimeTable.test.js
@@ -48,7 +48,6 @@ describe("Section tests", () => {
       "Time",
       "Instructor",
       "Enroll Code",
-      ,
       "Info",
     ];
     const expectedFields = [

--- a/frontend/src/tests/components/Sections/SectionsOverTimeTable.test.js
+++ b/frontend/src/tests/components/Sections/SectionsOverTimeTable.test.js
@@ -47,7 +47,8 @@ describe("Section tests", () => {
       "Days",
       "Time",
       "Instructor",
-      "Enroll Code",
+      "Enroll Code",,
+      "Info",
     ];
     const expectedFields = [
       "quarter",
@@ -60,6 +61,7 @@ describe("Section tests", () => {
       "time",
       "instructor",
       "section.enrollCode",
+      "info",
     ];
     const testId = "SectionsOverTimeTable";
 
@@ -100,6 +102,9 @@ describe("Section tests", () => {
       screen.getByTestId(`${testId}-cell-row-5-col-instructor`),
     ).toHaveTextContent("DANESHAMOOZ J, KILGORE J D, YANG YIFAN");
     expect(
+      screen.getByTestId(`${testId}-cell-row-5-col-info`).children[0]
+    ).toHaveTextContent("ⓘ");
+    expect(
       screen.getByTestId(`${testId}-cell-row-5-col-courseInfo.courseId`),
     ).not.toHaveTextContent("CMPSC 130A -1");
   });
@@ -124,6 +129,7 @@ describe("Section tests", () => {
       "Time",
       "Instructor",
       "Enroll Code",
+      "Info",
     ];
     const expectedFields = [
       "quarter",
@@ -136,6 +142,7 @@ describe("Section tests", () => {
       "time",
       "instructor",
       "section.enrollCode",
+      "info",
     ];
     const testId = "SectionsOverTimeTable";
 
@@ -181,6 +188,12 @@ describe("Section tests", () => {
     expect(
       screen.getByTestId(`${testId}-cell-row-0-col-section.enrollCode`),
     ).toHaveTextContent("08078");
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-info`).children[0]
+    ).toHaveTextContent("ⓘ");
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-info`).children[0].href
+    ).toMatch(/\/course\/details\/20222\/08078$/);
   });
 
   test("Correctly groups separate quarters of the same class", async () => {

--- a/frontend/src/tests/components/Sections/SectionsTable.test.js
+++ b/frontend/src/tests/components/Sections/SectionsTable.test.js
@@ -183,7 +183,7 @@ describe("Section tests", () => {
     ).toHaveTextContent("ⓘ");
     expect(
       screen.getByTestId(`${testId}-cell-row-0-col-info`).children[0].href,
-    ).toMatch(/\/course\/details\/20221\/12583$/);
+    ).toMatch(/\/coursedetails\/20221\/12583$/);
   });
 
   test("Correctly groups separate lectures of the same class", async () => {

--- a/frontend/src/tests/components/Sections/SectionsTable.test.js
+++ b/frontend/src/tests/components/Sections/SectionsTable.test.js
@@ -98,7 +98,7 @@ describe("Section tests", () => {
       screen.getByTestId(`${testId}-cell-row-2-col-instructor`),
     ).toHaveTextContent("YUNG A S");
     expect(
-      screen.getByTestId(`${testId}-cell-row-2-col-info`).children[0]
+      screen.getByTestId(`${testId}-cell-row-2-col-info`).children[0],
     ).toHaveTextContent("ⓘ");
   });
 
@@ -179,10 +179,10 @@ describe("Section tests", () => {
       screen.getByTestId(`${testId}-cell-row-0-col-section.enrollCode`),
     ).toHaveTextContent("12583");
     expect(
-      screen.getByTestId(`${testId}-cell-row-0-col-info`).children[0]
+      screen.getByTestId(`${testId}-cell-row-0-col-info`).children[0],
     ).toHaveTextContent("ⓘ");
     expect(
-      screen.getByTestId(`${testId}-cell-row-0-col-info`).children[0].href
+      screen.getByTestId(`${testId}-cell-row-0-col-info`).children[0].href,
     ).toMatch(/\/course\/details\/20221\/12583$/);
   });
 

--- a/frontend/src/tests/components/Sections/SectionsTable.test.js
+++ b/frontend/src/tests/components/Sections/SectionsTable.test.js
@@ -44,6 +44,7 @@ describe("Section tests", () => {
       "Time",
       "Instructor",
       "Enroll Code",
+      "Info",
     ];
     const expectedFields = [
       "quarter",
@@ -56,6 +57,7 @@ describe("Section tests", () => {
       "time",
       "instructor",
       "section.enrollCode",
+      "info",
     ];
     const testId = "SectionsTable";
 
@@ -95,6 +97,9 @@ describe("Section tests", () => {
     expect(
       screen.getByTestId(`${testId}-cell-row-2-col-instructor`),
     ).toHaveTextContent("YUNG A S");
+    expect(
+      screen.getByTestId(`${testId}-cell-row-2-col-info`).children[0]
+    ).toHaveTextContent("ⓘ");
   });
 
   test("Has the expected column headers and content", async () => {
@@ -117,6 +122,7 @@ describe("Section tests", () => {
       "Time",
       "Instructor",
       "Enroll Code",
+      "Info",
     ];
     const expectedFields = [
       "quarter",
@@ -129,6 +135,7 @@ describe("Section tests", () => {
       "time",
       "instructor",
       "section.enrollCode",
+      "info",
     ];
     const testId = "SectionsTable";
 
@@ -171,6 +178,12 @@ describe("Section tests", () => {
     expect(
       screen.getByTestId(`${testId}-cell-row-0-col-section.enrollCode`),
     ).toHaveTextContent("12583");
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-info`).children[0]
+    ).toHaveTextContent("ⓘ");
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-info`).children[0].href
+    ).toMatch(/\/course\/details\/20221\/12583$/);
   });
 
   test("Correctly groups separate lectures of the same class", async () => {


### PR DESCRIPTION
Closes #14 

In this PR we add a course info button as a new column on the right of the course table, and updated the tests. While #13 is not yet implemented (and thus the button's navigation goes to a blank page), Daniel and I have already agreed to use the `/coursedetails/yyyyq/enrollcode` format rather than `qyy`, so the proper page should indeed show once that issue has been closed.

A working version of this change is available at https://proj-courses-irreflexive-dev.dokku-09.cs.ucsb.edu/. Ensure that the resulting URL after clicking on the button corresponds to the proper course enrollment code and quarter.
![image](https://github.com/ucsb-cs156-f23/proj-courses-f23-7pm-1/assets/33270232/817bff08-9075-428a-9cb6-0802cc0b9cc3)