### PR TITLE
Added Backend Endpoint to Retrieve Final Exam Information

### DIFF
--- a/src/main/java/edu/ucsb/cs156/courses/controllers/UCSBFinalExamController.java
+++ b/src/main/java/edu/ucsb/cs156/courses/controllers/UCSBFinalExamController.java
@@ -2,6 +2,8 @@ package edu.ucsb.cs156.courses.controllers;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+
+import edu.ucsb.cs156.courses.models.Quarter;
 import edu.ucsb.cs156.courses.repositories.UserRepository;
 import edu.ucsb.cs156.courses.services.UCSBCurriculumService;
 import lombok.extern.slf4j.Slf4j;
@@ -28,21 +30,9 @@ public class UCSBFinalExamController {
       @RequestParam String qxx, @RequestParam String enrollCd)
       throws JsonProcessingException {
 
-    char q = qxx.charAt(0);
-    String yearDigits = qxx.substring(1);
+    Quarter quarter = new Quarter(qxx.toUpperCase());
 
-    String quarterNumber;
-    switch (q) {
-      case 'w': quarterNumber = "1"; break;
-      case 's': quarterNumber = "2"; break;
-      case 'm': quarterNumber = "3"; break;
-      case 'f': quarterNumber = "4"; break;
-      default: quarterNumber = "?";
-    }
-    
-    String quarter = "20" + yearDigits + quarterNumber;
-
-    String body = ucsbCurriculumService.getFinalExamInfo(quarter, enrollCd);
+    String body = ucsbCurriculumService.getFinalExamInfo(quarter.getYYYYQ(), enrollCd);
 
     return ResponseEntity.ok().body(body);
   }

--- a/src/main/java/edu/ucsb/cs156/courses/controllers/UCSBFinalExamController.java
+++ b/src/main/java/edu/ucsb/cs156/courses/controllers/UCSBFinalExamController.java
@@ -1,0 +1,49 @@
+package edu.ucsb.cs156.courses.controllers;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import edu.ucsb.cs156.courses.repositories.UserRepository;
+import edu.ucsb.cs156.courses.services.UCSBCurriculumService;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/finalsInfo")
+public class UCSBFinalExamController {
+
+  private ObjectMapper mapper = new ObjectMapper();
+
+  @Autowired UserRepository userRepository;
+
+  @Autowired UCSBCurriculumService ucsbCurriculumService;
+
+  @GetMapping(value = "", produces = "application/json")
+  public ResponseEntity<String> finalsinfo(
+      @RequestParam String qxx, @RequestParam String enrollCd)
+      throws JsonProcessingException {
+
+    char q = qxx.charAt(0);
+    String yearDigits = qxx.substring(1);
+
+    String quarterNumber;
+    switch (q) {
+      case 'w': quarterNumber = "1"; break;
+      case 's': quarterNumber = "2"; break;
+      case 'm': quarterNumber = "3"; break;
+      case 'f': quarterNumber = "4"; break;
+      default: quarterNumber = "?";
+    }
+    
+    String quarter = "20" + yearDigits + quarterNumber;
+
+    String body = ucsbCurriculumService.getFinalExamInfo(quarter, enrollCd);
+
+    return ResponseEntity.ok().body(body);
+  }
+}

--- a/src/main/java/edu/ucsb/cs156/courses/controllers/UCSBFinalExamController.java
+++ b/src/main/java/edu/ucsb/cs156/courses/controllers/UCSBFinalExamController.java
@@ -3,7 +3,6 @@ package edu.ucsb.cs156.courses.controllers;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import edu.ucsb.cs156.courses.models.Quarter;
 import edu.ucsb.cs156.courses.repositories.UserRepository;
 import edu.ucsb.cs156.courses.services.UCSBCurriculumService;
 import lombok.extern.slf4j.Slf4j;
@@ -30,9 +29,7 @@ public class UCSBFinalExamController {
       @RequestParam String qxx, @RequestParam String enrollCd)
       throws JsonProcessingException {
 
-    Quarter quarter = new Quarter(qxx.toUpperCase());
-
-    String body = ucsbCurriculumService.getFinalExamInfo(quarter.getYYYYQ(), enrollCd);
+    String body = ucsbCurriculumService.getFinalExamInfo(qxx, enrollCd);
 
     return ResponseEntity.ok().body(body);
   }

--- a/src/main/java/edu/ucsb/cs156/courses/controllers/UCSBFinalExamController.java
+++ b/src/main/java/edu/ucsb/cs156/courses/controllers/UCSBFinalExamController.java
@@ -2,7 +2,6 @@ package edu.ucsb.cs156.courses.controllers;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-
 import edu.ucsb.cs156.courses.repositories.UserRepository;
 import edu.ucsb.cs156.courses.services.UCSBCurriculumService;
 import lombok.extern.slf4j.Slf4j;
@@ -25,8 +24,7 @@ public class UCSBFinalExamController {
   @Autowired UCSBCurriculumService ucsbCurriculumService;
 
   @GetMapping(value = "", produces = "application/json")
-  public ResponseEntity<String> finalsinfo(
-      @RequestParam String qxx, @RequestParam String enrollCd)
+  public ResponseEntity<String> finalsinfo(@RequestParam String qxx, @RequestParam String enrollCd)
       throws JsonProcessingException {
 
     String body = ucsbCurriculumService.getFinalExamInfo(qxx, enrollCd);

--- a/src/main/java/edu/ucsb/cs156/courses/services/UCSBCurriculumService.java
+++ b/src/main/java/edu/ucsb/cs156/courses/services/UCSBCurriculumService.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import edu.ucsb.cs156.courses.documents.ConvertedSection;
 import edu.ucsb.cs156.courses.documents.CoursePage;
 import edu.ucsb.cs156.courses.models.Quarter;
-
 import java.io.*;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -54,7 +53,7 @@ public class UCSBCurriculumService {
   public static final String ALL_SECTIONS_ENDPOINT =
       "https://api.ucsb.edu/academics/curriculums/v3/classes/{quarter}/{enrollcode}";
 
-  public static final String FINALS_ENDPOINT = 
+  public static final String FINALS_ENDPOINT =
       "https://api.ucsb.edu/academics/curriculums/v3/finals";
 
   public String getJSON(String subjectArea, String quarter, String courseLevel) {
@@ -262,11 +261,11 @@ public class UCSBCurriculumService {
         "https://api.ucsb.edu/academics/curriculums/v3/classsection/" + quarter + "/" + enrollCd;
 
     String urlTemplate =
-      UriComponentsBuilder.fromHttpUrl(url)
-          .queryParam("quarter", "{quarter}")
-          .queryParam("enrollCode", "{enrollCode}")
-          .encode()
-          .toUriString();
+        UriComponentsBuilder.fromHttpUrl(url)
+            .queryParam("quarter", "{quarter}")
+            .queryParam("enrollCode", "{enrollCode}")
+            .encode()
+            .toUriString();
 
     log.info("url=" + url);
 
@@ -301,10 +300,7 @@ public class UCSBCurriculumService {
       log.info("invalid quarter format: {}", quarter);
     }
 
-    String params =
-        String.format(
-            "?quarter=%s&enrollCode=%s",
-            quarter, enrollCd);
+    String params = String.format("?quarter=%s&enrollCode=%s", quarter, enrollCd);
     String url = FINALS_ENDPOINT + params;
 
     log.info("url=" + url);

--- a/src/main/java/edu/ucsb/cs156/courses/services/UCSBCurriculumService.java
+++ b/src/main/java/edu/ucsb/cs156/courses/services/UCSBCurriculumService.java
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import edu.ucsb.cs156.courses.documents.ConvertedSection;
 import edu.ucsb.cs156.courses.documents.CoursePage;
+import edu.ucsb.cs156.courses.models.Quarter;
+
 import java.io.*;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -292,6 +294,12 @@ public class UCSBCurriculumService {
     headers.set("ucsb-api-key", this.apiKey);
 
     HttpEntity<String> entity = new HttpEntity<>("body", headers);
+
+    try {
+      quarter = new Quarter(quarter.toUpperCase()).getYYYYQ();
+    } catch (Exception e) {
+      log.info("invalid quarter format: {}", quarter);
+    }
 
     String params =
         String.format(

--- a/src/main/java/edu/ucsb/cs156/courses/services/UCSBCurriculumService.java
+++ b/src/main/java/edu/ucsb/cs156/courses/services/UCSBCurriculumService.java
@@ -52,6 +52,9 @@ public class UCSBCurriculumService {
   public static final String ALL_SECTIONS_ENDPOINT =
       "https://api.ucsb.edu/academics/curriculums/v3/classes/{quarter}/{enrollcode}";
 
+  public static final String FINALS_ENDPOINT = 
+      "https://api.ucsb.edu/academics/curriculums/v3/finals";
+
   public String getJSON(String subjectArea, String quarter, String courseLevel) {
 
     HttpHeaders headers = new HttpHeaders();
@@ -239,6 +242,10 @@ public class UCSBCurriculumService {
     return retVal;
   }
 
+  /*
+   * This method retrieves the final exam date and time information for the class specified
+   * by the enrollment code and quarter the course is being offered.
+   */
   public String getJSONbyQtrEnrollCd(String quarter, String enrollCd) {
 
     HttpHeaders headers = new HttpHeaders();
@@ -251,6 +258,46 @@ public class UCSBCurriculumService {
 
     String url =
         "https://api.ucsb.edu/academics/curriculums/v3/classsection/" + quarter + "/" + enrollCd;
+
+    String urlTemplate =
+      UriComponentsBuilder.fromHttpUrl(url)
+          .queryParam("quarter", "{quarter}")
+          .queryParam("enrollCode", "{enrollCode}")
+          .encode()
+          .toUriString();
+
+    log.info("url=" + url);
+
+    String retVal = "";
+    MediaType contentType = null;
+    HttpStatus statusCode = null;
+    try {
+      ResponseEntity<String> re = restTemplate.exchange(url, HttpMethod.GET, entity, String.class);
+      contentType = re.getHeaders().getContentType();
+      statusCode = re.getStatusCode();
+      retVal = re.getBody();
+    } catch (HttpClientErrorException e) {
+      retVal = "{\"error\": \"401: Unauthorized\"}";
+    }
+    log.info("json: {} contentType: {} statusCode: {}", retVal, contentType, statusCode);
+    return retVal;
+  }
+
+  public String getFinalExamInfo(String quarter, String enrollCd) {
+
+    HttpHeaders headers = new HttpHeaders();
+    headers.setAccept(Arrays.asList(MediaType.APPLICATION_JSON));
+    headers.setContentType(MediaType.APPLICATION_JSON);
+    headers.set("ucsb-api-version", "1.0");
+    headers.set("ucsb-api-key", this.apiKey);
+
+    HttpEntity<String> entity = new HttpEntity<>("body", headers);
+
+    String params =
+        String.format(
+            "?quarter=%s&enrollCode=%s",
+            quarter, enrollCd);
+    String url = FINALS_ENDPOINT + params;
 
     log.info("url=" + url);
 

--- a/src/test/java/edu/ucsb/cs156/courses/controllers/UCSBFinalExamControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/controllers/UCSBFinalExamControllerTests.java
@@ -1,0 +1,55 @@
+package edu.ucsb.cs156.courses.controllers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import edu.ucsb.cs156.courses.config.SecurityConfig;
+import edu.ucsb.cs156.courses.repositories.UserRepository;
+import edu.ucsb.cs156.courses.services.UCSBCurriculumService;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+@Slf4j
+@WebMvcTest(value = UCSBFinalExamController.class)
+@Import(SecurityConfig.class)
+@AutoConfigureDataJpa
+public class UCSBFinalExamControllerTests {
+
+  private ObjectMapper mapper = new ObjectMapper();
+
+  @MockBean UserRepository userRepository;
+
+  @Autowired private MockMvc mockMvc;
+
+  @MockBean private UCSBCurriculumService ucsbCurriculumService;
+
+  @Test
+  public void test_finals() throws Exception {
+
+    String expectedResult = "{expectedJSONResult}";
+    String urlTemplate = "/api/finalsInfo?qxx=%s&enrollCd=%s";
+    String url = String.format(urlTemplate, "w24", "04051");
+    when(ucsbCurriculumService.getFinalExamInfo(any(String.class), any(String.class)))
+        .thenReturn(expectedResult);
+
+    MvcResult response =
+        mockMvc
+            .perform(get(url).contentType("application/json"))
+            .andExpect(status().isOk())
+            .andReturn();
+    String responseString = response.getResponse().getContentAsString();
+
+    assertEquals(expectedResult, responseString);
+  }
+}

--- a/src/test/java/edu/ucsb/cs156/courses/services/UCSBCurriculumServiceTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/services/UCSBCurriculumServiceTests.java
@@ -423,4 +423,60 @@ public class UCSBCurriculumServiceTests {
     String result = ucs.getAllSections(enrollCode, quarter);
     assertEquals(expectedResult, result);
   }
+
+  @Test
+  public void test_getFinalExamInfo_success() throws Exception {
+    String expectedResult = "{expectedResult}";
+
+    String enrollCd = "04051";
+    String quarter = "20241";
+
+    String expectedParams =
+        String.format(
+            "?quarter=%s&enrollCode=%s",
+            quarter, enrollCd);
+    String expectedURL = UCSBCurriculumService.FINALS_ENDPOINT + expectedParams;
+
+    this.mockRestServiceServer
+        .expect(requestTo(expectedURL))
+        .andExpect(header("Accept", MediaType.APPLICATION_JSON.toString()))
+        .andExpect(header("Content-Type", MediaType.APPLICATION_JSON.toString()))
+        .andExpect(header("ucsb-api-version", "1.0"))
+        .andExpect(header("ucsb-api-key", apiKey))
+        .andRespond(withSuccess(expectedResult, MediaType.APPLICATION_JSON));
+
+    String result = ucs.getFinalExamInfo(quarter, enrollCd);
+
+    assertEquals(expectedResult, result);
+  }
+
+  @Test
+  public void test_getFinalExamInfo_exception() throws Exception {
+    String expectedResult = "{\"error\": \"401: Unauthorized\"}";
+
+    when(restTemplate.exchange(
+            any(String.class), eq(HttpMethod.GET), any(HttpEntity.class), eq(String.class)))
+        .thenThrow(HttpClientErrorException.class);
+
+    String enrollCd = "04051";
+    String quarter = "20241";
+
+    String expectedParams =
+        String.format(
+            "?quarter=%s&enrollCode=%s",
+            quarter, enrollCd);
+    String expectedURL = UCSBCurriculumService.FINALS_ENDPOINT + expectedParams;
+
+    this.mockRestServiceServer
+        .expect(requestTo(expectedURL))
+        .andExpect(header("Accept", MediaType.APPLICATION_JSON.toString()))
+        .andExpect(header("Content-Type", MediaType.APPLICATION_JSON.toString()))
+        .andExpect(header("ucsb-api-version", "1.0"))
+        .andExpect(header("ucsb-api-key", apiKey))
+        .andRespond(withUnauthorizedRequest());
+
+    String result = ucs.getFinalExamInfo(quarter, enrollCd);
+
+    assertEquals(expectedResult, result);
+  }
 }

--- a/src/test/java/edu/ucsb/cs156/courses/services/UCSBCurriculumServiceTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/services/UCSBCurriculumServiceTests.java
@@ -429,7 +429,7 @@ public class UCSBCurriculumServiceTests {
     String expectedResult = "{expectedResult}";
 
     String enrollCd = "04051";
-    String quarter = "20241";
+    String quarter = "";
 
     String expectedParams =
         String.format(
@@ -444,6 +444,32 @@ public class UCSBCurriculumServiceTests {
         .andExpect(header("ucsb-api-version", "1.0"))
         .andExpect(header("ucsb-api-key", apiKey))
         .andRespond(withSuccess(expectedResult, MediaType.APPLICATION_JSON));
+
+    String result = ucs.getFinalExamInfo(quarter, enrollCd);
+
+    assertEquals(expectedResult, result);
+  }
+
+  @Test
+  public void test_getFinalExamInfo_invalid_quarter() throws Exception {
+    String expectedResult = "{\"error\": \"401: Unauthorized\"}";
+
+    String enrollCd = "04051";
+    String quarter = "20241";
+
+    String expectedParams =
+        String.format(
+            "?quarter=%s&enrollCode=%s",
+            quarter, enrollCd);
+    String expectedURL = UCSBCurriculumService.FINALS_ENDPOINT + expectedParams;
+
+    this.mockRestServiceServer
+        .expect(requestTo(expectedURL))
+        .andExpect(header("Accept", MediaType.APPLICATION_JSON.toString()))
+        .andExpect(header("Content-Type", MediaType.APPLICATION_JSON.toString()))
+        .andExpect(header("ucsb-api-version", "1.0"))
+        .andExpect(header("ucsb-api-key", apiKey))
+        .andRespond(withUnauthorizedRequest());
 
     String result = ucs.getFinalExamInfo(quarter, enrollCd);
 

--- a/src/test/java/edu/ucsb/cs156/courses/services/UCSBCurriculumServiceTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/services/UCSBCurriculumServiceTests.java
@@ -431,10 +431,7 @@ public class UCSBCurriculumServiceTests {
     String enrollCd = "04051";
     String quarter = "";
 
-    String expectedParams =
-        String.format(
-            "?quarter=%s&enrollCode=%s",
-            quarter, enrollCd);
+    String expectedParams = String.format("?quarter=%s&enrollCode=%s", quarter, enrollCd);
     String expectedURL = UCSBCurriculumService.FINALS_ENDPOINT + expectedParams;
 
     this.mockRestServiceServer
@@ -457,10 +454,7 @@ public class UCSBCurriculumServiceTests {
     String enrollCd = "04051";
     String quarter = "20241";
 
-    String expectedParams =
-        String.format(
-            "?quarter=%s&enrollCode=%s",
-            quarter, enrollCd);
+    String expectedParams = String.format("?quarter=%s&enrollCode=%s", quarter, enrollCd);
     String expectedURL = UCSBCurriculumService.FINALS_ENDPOINT + expectedParams;
 
     this.mockRestServiceServer
@@ -487,10 +481,7 @@ public class UCSBCurriculumServiceTests {
     String enrollCd = "04051";
     String quarter = "20241";
 
-    String expectedParams =
-        String.format(
-            "?quarter=%s&enrollCode=%s",
-            quarter, enrollCd);
+    String expectedParams = String.format("?quarter=%s&enrollCode=%s", quarter, enrollCd);
     String expectedURL = UCSBCurriculumService.FINALS_ENDPOINT + expectedParams;
 
     this.mockRestServiceServer


### PR DESCRIPTION
Closes #21 

In this PR we add a method to UCSBCurriculumService to retrieve final exam information. There is an associated endpoint, `/api/finalsInfo?qxx={quarter}&enrollCd={enrollcode}` available on Swagger to return this information. There are also tests for the service method and controller.

Below is an example of the endpoint working on Swagger, though it is not currently deployed to any dokku instance:
![image](https://github.com/ucsb-cs156-f23/proj-courses-f23-7pm-1/assets/33270232/04d3393b-c0da-481c-9ee7-9035d9938173)