### PR TITLE
Implemented Admin Job to Update Final Exam Info

### DIFF
--- a/frontend/src/main/pages/AdminJobsPage.js
+++ b/frontend/src/main/pages/AdminJobsPage.js
@@ -103,6 +103,10 @@ const AdminJobsPage = () => {
       name: "Update Grade Info",
       form: <JobComingSoon />,
     },
+    {
+      name: "Update Final Exam Info",
+      form: <JobComingSoon />,
+    },
   ];
 
   return (

--- a/frontend/src/tests/pages/AdminJobsPage.test.js
+++ b/frontend/src/tests/pages/AdminJobsPage.test.js
@@ -39,9 +39,12 @@ describe("AdminJobsPage tests", () => {
     expect(await screen.findByText("Launch Jobs")).toBeInTheDocument();
     expect(await screen.findByText("Job Status")).toBeInTheDocument();
 
-    ["Test Job", "Update Courses Database", "Update Grade Info", "Update Final Exam Info"].map(
-      (jobName) => expect(screen.getByText(jobName)).toBeInTheDocument(),
-    );
+    [
+      "Test Job",
+      "Update Courses Database",
+      "Update Grade Info",
+      "Update Final Exam Info",
+    ].map((jobName) => expect(screen.getByText(jobName)).toBeInTheDocument());
 
     const testId = "JobsTable";
 

--- a/frontend/src/tests/pages/AdminJobsPage.test.js
+++ b/frontend/src/tests/pages/AdminJobsPage.test.js
@@ -39,7 +39,7 @@ describe("AdminJobsPage tests", () => {
     expect(await screen.findByText("Launch Jobs")).toBeInTheDocument();
     expect(await screen.findByText("Job Status")).toBeInTheDocument();
 
-    ["Test Job", "Update Courses Database", "Update Grade Info"].map(
+    ["Test Job", "Update Courses Database", "Update Grade Info", "Update Final Exam Info"].map(
       (jobName) => expect(screen.getByText(jobName)).toBeInTheDocument(),
     );
 

--- a/src/main/java/edu/ucsb/cs156/courses/collections/ConvertedSectionCollection.java
+++ b/src/main/java/edu/ucsb/cs156/courses/collections/ConvertedSectionCollection.java
@@ -26,4 +26,8 @@ public interface ConvertedSectionCollection extends MongoRepository<ConvertedSec
       "{'courseInfo.quarter': { $gte: ?0, $lte: ?1 }, 'section.timeLocations.building': { $regex: ?2, $options: 'i' } }")
   List<ConvertedSection> findByQuarterRangeAndBuildingCode(
       String startQuarter, String endQuarter, String buildingCode);
+
+  @Query("{'courseInfo.quarter': { $gte: ?0, $lte: ?1 }}")
+  List<ConvertedSection> findByQuarterRange(
+      String startQuarter, String endQuarter);
 }

--- a/src/main/java/edu/ucsb/cs156/courses/collections/ConvertedSectionCollection.java
+++ b/src/main/java/edu/ucsb/cs156/courses/collections/ConvertedSectionCollection.java
@@ -28,6 +28,5 @@ public interface ConvertedSectionCollection extends MongoRepository<ConvertedSec
       String startQuarter, String endQuarter, String buildingCode);
 
   @Query("{'courseInfo.quarter': { $gte: ?0, $lte: ?1 }}")
-  List<ConvertedSection> findByQuarterRange(
-      String startQuarter, String endQuarter);
+  List<ConvertedSection> findByQuarterRange(String startQuarter, String endQuarter);
 }

--- a/src/main/java/edu/ucsb/cs156/courses/controllers/JobsController.java
+++ b/src/main/java/edu/ucsb/cs156/courses/controllers/JobsController.java
@@ -140,7 +140,8 @@ public class JobsController extends ApiController {
       @Parameter(name = "end_quarterYYYYQ", description = "end quarter (YYYYQ format)")
           @RequestParam
           String end_quarterYYYYQ) {
-    UpdateFinalsDataJob updateFinalsDataJob = updateFinalsDataJobFactory.createForQuarterRange(start_quarterYYYYQ, end_quarterYYYYQ);
+    UpdateFinalsDataJob updateFinalsDataJob =
+        updateFinalsDataJobFactory.createForQuarterRange(start_quarterYYYYQ, end_quarterYYYYQ);
     return jobService.runAsJob(updateFinalsDataJob);
   }
 }

--- a/src/main/java/edu/ucsb/cs156/courses/controllers/JobsController.java
+++ b/src/main/java/edu/ucsb/cs156/courses/controllers/JobsController.java
@@ -5,6 +5,8 @@ import edu.ucsb.cs156.courses.collections.ConvertedSectionCollection;
 import edu.ucsb.cs156.courses.entities.Job;
 import edu.ucsb.cs156.courses.jobs.TestJob;
 import edu.ucsb.cs156.courses.jobs.UpdateCourseDataJobFactory;
+import edu.ucsb.cs156.courses.jobs.UpdateFinalsDataJob;
+import edu.ucsb.cs156.courses.jobs.UpdateFinalsDataJobFactory;
 import edu.ucsb.cs156.courses.jobs.UploadGradeDataJob;
 import edu.ucsb.cs156.courses.jobs.UploadGradeDataJobFactory;
 import edu.ucsb.cs156.courses.repositories.JobsRepository;
@@ -35,6 +37,8 @@ public class JobsController extends ApiController {
   @Autowired UpdateCourseDataJobFactory updateCourseDataJobFactory;
 
   @Autowired UploadGradeDataJobFactory updateGradeDataJobFactory;
+
+  @Autowired UpdateFinalsDataJobFactory updateFinalsDataJobFactory;
 
   @Operation(summary = "List all jobs")
   @PreAuthorize("hasRole('ROLE_ADMIN')")
@@ -124,5 +128,19 @@ public class JobsController extends ApiController {
   public Job launchUploadGradeData() {
     UploadGradeDataJob updateGradeDataJob = updateGradeDataJobFactory.create();
     return jobService.runAsJob(updateGradeDataJob);
+  }
+
+  @Operation(summary = "Launch Job to update finals data for a range of quarters")
+  @PreAuthorize("hasRole('ROLE_ADMIN')")
+  @PostMapping("/launch/updateFinalsData")
+  public Job launchUpdateFinalsData(
+      @Parameter(name = "start_quarterYYYYQ", description = "start quarter (YYYYQ format)")
+          @RequestParam
+          String start_quarterYYYYQ,
+      @Parameter(name = "end_quarterYYYYQ", description = "end quarter (YYYYQ format)")
+          @RequestParam
+          String end_quarterYYYYQ) {
+    UpdateFinalsDataJob updateFinalsDataJob = updateFinalsDataJobFactory.createForQuarterRange(start_quarterYYYYQ, end_quarterYYYYQ);
+    return jobService.runAsJob(updateFinalsDataJob);
   }
 }

--- a/src/main/java/edu/ucsb/cs156/courses/documents/ConvertedSection.java
+++ b/src/main/java/edu/ucsb/cs156/courses/documents/ConvertedSection.java
@@ -31,8 +31,10 @@ public class ConvertedSection {
     Section newSection = (Section) this.getSection().clone();
     newConvertedSection.setSection(newSection);
 
-    FinalExam newFinalExam = (FinalExam) this.getFinalExam().clone();
-    newConvertedSection.setFinalExam(newFinalExam);
+    if (this.getFinalExam() != null) {
+      FinalExam newFinalExam = (FinalExam) this.getFinalExam().clone();
+      newConvertedSection.setFinalExam(newFinalExam);
+    }
 
     return newConvertedSection;
   }

--- a/src/main/java/edu/ucsb/cs156/courses/documents/ConvertedSection.java
+++ b/src/main/java/edu/ucsb/cs156/courses/documents/ConvertedSection.java
@@ -16,6 +16,7 @@ public class ConvertedSection {
   private ObjectId _id;
   private CourseInfo courseInfo;
   private Section section;
+  private FinalExam finalExam;
 
   @Override
   public Object clone() throws CloneNotSupportedException {
@@ -29,6 +30,9 @@ public class ConvertedSection {
 
     Section newSection = (Section) this.getSection().clone();
     newConvertedSection.setSection(newSection);
+
+    FinalExam newFinalExam = (FinalExam) this.getFinalExam().clone();
+    newConvertedSection.setFinalExam(newFinalExam);
 
     return newConvertedSection;
   }

--- a/src/main/java/edu/ucsb/cs156/courses/documents/FinalExam.java
+++ b/src/main/java/edu/ucsb/cs156/courses/documents/FinalExam.java
@@ -9,11 +9,18 @@ import lombok.NoArgsConstructor;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class FinalExam {
+public class FinalExam implements Cloneable {
   private boolean hasFinals;
   private String comments;
   private String examDay;
   private String examDate;
   private String beginTime;
   private String endTime;
+
+  public Object clone() throws CloneNotSupportedException {
+
+    FinalExam newFinalExam = (FinalExam) super.clone();
+
+    return newFinalExam;
+  }
 }

--- a/src/main/java/edu/ucsb/cs156/courses/jobs/UpdateFinalsDataJob.java
+++ b/src/main/java/edu/ucsb/cs156/courses/jobs/UpdateFinalsDataJob.java
@@ -18,7 +18,6 @@ import lombok.Getter;
 public class UpdateFinalsDataJob implements JobContextConsumer {
   private String start_quarterYYYYQ;
   private String end_quarterYYYYQ;
-  private List<String> subjects;
   private UCSBCurriculumService ucsbCurriculumService;
   private ConvertedSectionCollection convertedSectionCollection;
 

--- a/src/main/java/edu/ucsb/cs156/courses/jobs/UpdateFinalsDataJob.java
+++ b/src/main/java/edu/ucsb/cs156/courses/jobs/UpdateFinalsDataJob.java
@@ -45,19 +45,16 @@ public class UpdateFinalsDataJob implements JobContextConsumer {
     int updatedSections = 0;
     int errors = 0;
 
-    for (ConvertedSection section : convertedSectionCollection.findAll()) {
-      String quarter = section.getCourseInfo().getQuarter();
+    for (ConvertedSection section : convertedSections) {
       String enrollCd = section.getSection().getEnrollCode();
-      if (quarter.equals(quarterYYYYQ)) {
-        try {
-          FinalExam finalExam = ucsbCurriculumService.getFinalExamObject(quarter, enrollCd);
-          section.setFinalExam(finalExam);
-          convertedSectionCollection.save(section);
-          updatedSections++;
-        } catch (Exception e) {
-          ctx.log("Error saving final exam: " + e.getMessage());
-          errors++;
-        }
+      try {
+        FinalExam finalExam = ucsbCurriculumService.getFinalExamObject(quarterYYYYQ, enrollCd);
+        section.setFinalExam(finalExam);
+        convertedSectionCollection.save(section);
+        updatedSections++;
+      } catch (Exception e) {
+        ctx.log("Error saving final exam: " + e.getMessage());
+        errors++;
       }
     }
 

--- a/src/main/java/edu/ucsb/cs156/courses/jobs/UpdateFinalsDataJob.java
+++ b/src/main/java/edu/ucsb/cs156/courses/jobs/UpdateFinalsDataJob.java
@@ -10,6 +10,9 @@ import edu.ucsb.cs156.courses.services.jobs.JobContext;
 import edu.ucsb.cs156.courses.services.jobs.JobContextConsumer;
 import java.util.List;
 import java.util.Optional;
+
+import javax.security.auth.Subject;
+
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -35,7 +38,7 @@ public class UpdateFinalsDataJob implements JobContextConsumer {
     ctx.log("Updating final exam info for [" + quarterYYYYQ + "]");
 
     List<ConvertedSection> convertedSections =
-        convertedSectionCollection.findAll();
+        convertedSectionCollection.findByQuarterRange(quarterYYYYQ, quarterYYYYQ);
 
     ctx.log("Attempting to update final exams for " + convertedSections.size() + " sections in MongoDB...");
 

--- a/src/main/java/edu/ucsb/cs156/courses/jobs/UpdateFinalsDataJob.java
+++ b/src/main/java/edu/ucsb/cs156/courses/jobs/UpdateFinalsDataJob.java
@@ -1,0 +1,68 @@
+package edu.ucsb.cs156.courses.jobs;
+
+import edu.ucsb.cs156.courses.collections.ConvertedSectionCollection;
+import edu.ucsb.cs156.courses.documents.ConvertedSection;
+import edu.ucsb.cs156.courses.documents.CoursePage;
+import edu.ucsb.cs156.courses.documents.FinalExam;
+import edu.ucsb.cs156.courses.models.Quarter;
+import edu.ucsb.cs156.courses.services.UCSBCurriculumService;
+import edu.ucsb.cs156.courses.services.jobs.JobContext;
+import edu.ucsb.cs156.courses.services.jobs.JobContextConsumer;
+import java.util.List;
+import java.util.Optional;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class UpdateFinalsDataJob implements JobContextConsumer {
+  private String start_quarterYYYYQ;
+  private String end_quarterYYYYQ;
+  private List<String> subjects;
+  private UCSBCurriculumService ucsbCurriculumService;
+  private ConvertedSectionCollection convertedSectionCollection;
+
+  @Override
+  public void accept(JobContext ctx) throws Exception {
+    List<Quarter> quarters = Quarter.quarterList(start_quarterYYYYQ, end_quarterYYYYQ);
+    for (Quarter quarter : quarters) {
+      String quarterYYYYQ = quarter.getYYYYQ();
+      updateFinals(ctx, quarterYYYYQ);
+    }
+  }
+
+  public void updateFinals(JobContext ctx, String quarterYYYYQ)
+      throws Exception {
+    ctx.log("Updating final exam info for [" + quarterYYYYQ + "]");
+
+    List<ConvertedSection> convertedSections =
+        convertedSectionCollection.findAll();
+
+    ctx.log("Attempting to update final exams for " + convertedSections.size() + " sections in MongoDB...");
+
+    int updatedSections = 0;
+    int errors = 0;
+
+    for (ConvertedSection section : convertedSectionCollection.findAll()) {
+      String quarter = section.getCourseInfo().getQuarter();
+      String enrollCd = section.getSection().getEnrollCode();
+      if (quarter.equals(quarterYYYYQ)) {
+        try {
+          FinalExam finalExam = ucsbCurriculumService.getFinalExamObject(quarter, enrollCd);
+          section.setFinalExam(finalExam);
+          convertedSectionCollection.save(section);
+          updatedSections++;
+        } catch (Exception e) {
+          ctx.log("Error saving final exam: " + e.getMessage());
+          errors++;
+        }
+      }
+    }
+
+    ctx.log(
+        String.format(
+            "%d final exams updated, %d errors",
+            updatedSections, errors));
+    ctx.log("Final exam info for [" + quarterYYYYQ + "] has been updated");
+  }
+}

--- a/src/main/java/edu/ucsb/cs156/courses/jobs/UpdateFinalsDataJob.java
+++ b/src/main/java/edu/ucsb/cs156/courses/jobs/UpdateFinalsDataJob.java
@@ -2,17 +2,12 @@ package edu.ucsb.cs156.courses.jobs;
 
 import edu.ucsb.cs156.courses.collections.ConvertedSectionCollection;
 import edu.ucsb.cs156.courses.documents.ConvertedSection;
-import edu.ucsb.cs156.courses.documents.CoursePage;
 import edu.ucsb.cs156.courses.documents.FinalExam;
 import edu.ucsb.cs156.courses.models.Quarter;
 import edu.ucsb.cs156.courses.services.UCSBCurriculumService;
 import edu.ucsb.cs156.courses.services.jobs.JobContext;
 import edu.ucsb.cs156.courses.services.jobs.JobContextConsumer;
 import java.util.List;
-import java.util.Optional;
-
-import javax.security.auth.Subject;
-
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -33,14 +28,16 @@ public class UpdateFinalsDataJob implements JobContextConsumer {
     }
   }
 
-  public void updateFinals(JobContext ctx, String quarterYYYYQ)
-      throws Exception {
+  public void updateFinals(JobContext ctx, String quarterYYYYQ) throws Exception {
     ctx.log("Updating final exam info for [" + quarterYYYYQ + "]");
 
     List<ConvertedSection> convertedSections =
         convertedSectionCollection.findByQuarterRange(quarterYYYYQ, quarterYYYYQ);
 
-    ctx.log("Attempting to update final exams for " + convertedSections.size() + " sections in MongoDB...");
+    ctx.log(
+        "Attempting to update final exams for "
+            + convertedSections.size()
+            + " sections in MongoDB...");
 
     int updatedSections = 0;
     int errors = 0;
@@ -58,10 +55,7 @@ public class UpdateFinalsDataJob implements JobContextConsumer {
       }
     }
 
-    ctx.log(
-        String.format(
-            "%d final exams updated, %d errors",
-            updatedSections, errors));
+    ctx.log(String.format("%d final exams updated, %d errors", updatedSections, errors));
     ctx.log("Final exam info for [" + quarterYYYYQ + "] has been updated");
   }
 }

--- a/src/main/java/edu/ucsb/cs156/courses/jobs/UpdateFinalsDataJobFactory.java
+++ b/src/main/java/edu/ucsb/cs156/courses/jobs/UpdateFinalsDataJobFactory.java
@@ -1,0 +1,19 @@
+package edu.ucsb.cs156.courses.jobs;
+
+import edu.ucsb.cs156.courses.collections.ConvertedSectionCollection;
+import edu.ucsb.cs156.courses.services.UCSBCurriculumService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class UpdateFinalsDataJobFactory {
+
+  @Autowired private UCSBCurriculumService ucsbCurriculumService;
+
+  @Autowired private ConvertedSectionCollection convertedSectionCollection;
+
+  public UploadGradeDataJob createForQuarterRange(
+      String start_quarterYYYYQ, String end_quarterYYYYQ) {
+    return new UpdateFinalsDataJob(start_quarterYYYYQ, end_quarterYYYYQ, ucsbCurriculumService, convertedSectionCollection);
+  }
+}

--- a/src/main/java/edu/ucsb/cs156/courses/jobs/UpdateFinalsDataJobFactory.java
+++ b/src/main/java/edu/ucsb/cs156/courses/jobs/UpdateFinalsDataJobFactory.java
@@ -12,7 +12,7 @@ public class UpdateFinalsDataJobFactory {
 
   @Autowired private ConvertedSectionCollection convertedSectionCollection;
 
-  public UploadGradeDataJob createForQuarterRange(
+  public UpdateFinalsDataJob createForQuarterRange(
       String start_quarterYYYYQ, String end_quarterYYYYQ) {
     return new UpdateFinalsDataJob(start_quarterYYYYQ, end_quarterYYYYQ, ucsbCurriculumService, convertedSectionCollection);
   }

--- a/src/main/java/edu/ucsb/cs156/courses/jobs/UpdateFinalsDataJobFactory.java
+++ b/src/main/java/edu/ucsb/cs156/courses/jobs/UpdateFinalsDataJobFactory.java
@@ -14,6 +14,7 @@ public class UpdateFinalsDataJobFactory {
 
   public UpdateFinalsDataJob createForQuarterRange(
       String start_quarterYYYYQ, String end_quarterYYYYQ) {
-    return new UpdateFinalsDataJob(start_quarterYYYYQ, end_quarterYYYYQ, ucsbCurriculumService, convertedSectionCollection);
+    return new UpdateFinalsDataJob(
+        start_quarterYYYYQ, end_quarterYYYYQ, ucsbCurriculumService, convertedSectionCollection);
   }
 }

--- a/src/main/java/edu/ucsb/cs156/courses/services/UCSBCurriculumService.java
+++ b/src/main/java/edu/ucsb/cs156/courses/services/UCSBCurriculumService.java
@@ -321,7 +321,7 @@ public class UCSBCurriculumService {
     return retVal;
   }
 
-  public FinalExam getFinalExamObject(String quarter, String enrollCd) {
+  public FinalExam getFinalExamObject(String quarter, String enrollCd) throws JsonProcessingException {
     String json = getFinalExamInfo(quarter, enrollCd);
     FinalExam finalExam = objectMapper.readValue(json, FinalExam.class);
     return finalExam;

--- a/src/main/java/edu/ucsb/cs156/courses/services/UCSBCurriculumService.java
+++ b/src/main/java/edu/ucsb/cs156/courses/services/UCSBCurriculumService.java
@@ -321,7 +321,8 @@ public class UCSBCurriculumService {
     return retVal;
   }
 
-  public FinalExam getFinalExamObject(String quarter, String enrollCd) throws JsonProcessingException {
+  public FinalExam getFinalExamObject(String quarter, String enrollCd)
+      throws JsonProcessingException {
     String json = getFinalExamInfo(quarter, enrollCd);
     FinalExam finalExam = objectMapper.readValue(json, FinalExam.class);
     return finalExam;

--- a/src/main/java/edu/ucsb/cs156/courses/services/UCSBCurriculumService.java
+++ b/src/main/java/edu/ucsb/cs156/courses/services/UCSBCurriculumService.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import edu.ucsb.cs156.courses.documents.ConvertedSection;
 import edu.ucsb.cs156.courses.documents.CoursePage;
+import edu.ucsb.cs156.courses.documents.FinalExam;
 import edu.ucsb.cs156.courses.models.Quarter;
 import java.io.*;
 import java.util.Arrays;
@@ -318,5 +319,11 @@ public class UCSBCurriculumService {
     }
     log.info("json: {} contentType: {} statusCode: {}", retVal, contentType, statusCode);
     return retVal;
+  }
+
+  public FinalExam getFinalExamObject(String quarter, String enrollCd) {
+    String json = getFinalExamInfo(quarter, enrollCd);
+    FinalExam finalExam = objectMapper.readValue(json, FinalExam.class);
+    return finalExam;
   }
 }

--- a/src/test/java/edu/ucsb/cs156/courses/controllers/JobsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/controllers/JobsControllerTests.java
@@ -287,4 +287,24 @@ public class JobsControllerTests extends ControllerTestCase {
 
     assertNotNull(jobReturned.getStatus());
   }
+
+  @WithMockUser(roles = {"ADMIN"})
+  @Test
+  public void admin_can_launch_update_finals_data_job() throws Exception {
+    // act
+    MvcResult response =
+        mockMvc
+            .perform(
+                post("/api/jobs/launch/updateFinalsData?start_quarterYYYYQ=20221&end_quarterYYYYQ=20222")
+                    .with(csrf()))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    // assert
+    String responseString = response.getResponse().getContentAsString();
+    log.info("responseString={}", responseString);
+    Job jobReturned = objectMapper.readValue(responseString, Job.class);
+
+    assertNotNull(jobReturned.getStatus());
+  }
 }

--- a/src/test/java/edu/ucsb/cs156/courses/controllers/JobsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/controllers/JobsControllerTests.java
@@ -18,6 +18,7 @@ import edu.ucsb.cs156.courses.collections.ConvertedSectionCollection;
 import edu.ucsb.cs156.courses.entities.Job;
 import edu.ucsb.cs156.courses.entities.User;
 import edu.ucsb.cs156.courses.jobs.UpdateCourseDataJobFactory;
+import edu.ucsb.cs156.courses.jobs.UpdateFinalsDataJobFactory;
 import edu.ucsb.cs156.courses.jobs.UploadGradeDataJobFactory;
 import edu.ucsb.cs156.courses.repositories.JobsRepository;
 import edu.ucsb.cs156.courses.repositories.UserRepository;
@@ -57,6 +58,8 @@ public class JobsControllerTests extends ControllerTestCase {
   @MockBean UCSBCurriculumService ucsbCurriculumService;
 
   @MockBean UpdateCourseDataJobFactory updateCourseDataJobFactory;
+
+  @MockBean UpdateFinalsDataJobFactory updateFinalsDataJobFactory;
 
   @MockBean ConvertedSectionCollection convertedSectionCollection;
 

--- a/src/test/java/edu/ucsb/cs156/courses/documents/ConvertedSectionTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/documents/ConvertedSectionTests.java
@@ -32,5 +32,8 @@ public class ConvertedSectionTests {
     cs1.set_id(new ObjectId());
     ConvertedSection cs2 = (ConvertedSection) cs1.clone();
     assertEquals(cs1, cs2);
+    cs2.setFinalExam(new FinalExam());
+    ConvertedSection cs3 = (ConvertedSection) cs2.clone();
+    assertEquals(cs2, cs3);
   }
 }

--- a/src/test/java/edu/ucsb/cs156/courses/jobs/UpdateFinalsDataJobFactoryTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/jobs/UpdateFinalsDataJobFactoryTests.java
@@ -1,0 +1,36 @@
+package edu.ucsb.cs156.courses.jobs;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;
+import org.springframework.boot.test.autoconfigure.web.client.RestClientTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+import edu.ucsb.cs156.courses.collections.ConvertedSectionCollection;
+import edu.ucsb.cs156.courses.services.UCSBCurriculumService;
+
+@RestClientTest(UpdateFinalsDataJobFactory.class)
+@AutoConfigureDataJpa
+public class UpdateFinalsDataJobFactoryTests {
+
+  @MockBean UCSBCurriculumService ucsbCurriculumService;
+
+  @MockBean ConvertedSectionCollection convertedSectionCollection;
+
+  @Autowired UpdateFinalsDataJobFactory factory;
+
+  @Test
+  void test_createForQuarterRange() throws Exception {
+
+    // Act
+
+    UpdateFinalsDataJob updateFinalsDataJob = factory.createForQuarterRange("20221", "20222");
+
+    // Assert
+
+    assertEquals("20221", updateFinalsDataJob.getStart_quarterYYYYQ());
+    assertEquals("20222", updateFinalsDataJob.getEnd_quarterYYYYQ());
+  }
+}

--- a/src/test/java/edu/ucsb/cs156/courses/jobs/UpdateFinalsDataJobFactoryTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/jobs/UpdateFinalsDataJobFactoryTests.java
@@ -2,14 +2,13 @@ package edu.ucsb.cs156.courses.jobs;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import edu.ucsb.cs156.courses.collections.ConvertedSectionCollection;
+import edu.ucsb.cs156.courses.services.UCSBCurriculumService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;
 import org.springframework.boot.test.autoconfigure.web.client.RestClientTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-
-import edu.ucsb.cs156.courses.collections.ConvertedSectionCollection;
-import edu.ucsb.cs156.courses.services.UCSBCurriculumService;
 
 @RestClientTest(UpdateFinalsDataJobFactory.class)
 @AutoConfigureDataJpa

--- a/src/test/java/edu/ucsb/cs156/courses/jobs/UpdateFinalsDataJobTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/jobs/UpdateFinalsDataJobTests.java
@@ -1,0 +1,155 @@
+package edu.ucsb.cs156.courses.jobs;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+import edu.ucsb.cs156.courses.collections.ConvertedSectionCollection;
+import edu.ucsb.cs156.courses.documents.ConvertedSection;
+import edu.ucsb.cs156.courses.documents.CoursePage;
+import edu.ucsb.cs156.courses.documents.CoursePageFixtures;
+import edu.ucsb.cs156.courses.entities.Job;
+import edu.ucsb.cs156.courses.services.UCSBCurriculumService;
+import edu.ucsb.cs156.courses.services.jobs.JobContext;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class UpdateFinalsDataJobTests {
+  @Mock UCSBCurriculumService ucsbCurriculumService;
+
+  @Mock ConvertedSectionCollection convertedSectionCollection;
+
+  Job jobStarted = Job.builder().build();
+  JobContext ctx = new JobContext(null, jobStarted);
+
+  @Test
+  void test_subject_and_quarter_range() throws Exception {
+
+    var job =
+        spy(
+            new UpdateFinalsDataJob(
+                "20211",
+                "20213",
+                ucsbCurriculumService,
+                convertedSectionCollection));
+    doNothing().when(job).updateFinals(any(), any());
+
+    job.accept(ctx);
+
+    verify(job).updateFinals(ctx, "20211");
+    verify(job).updateFinals(ctx, "20212");
+    verify(job).updateFinals(ctx, "20213");
+  }
+
+  @Test
+  void test_log_output_success() throws Exception {
+
+    // Act
+    var job =
+        new UpdateFinalsDataJob(
+            "20211", "20211", ucsbCurriculumService, convertedSectionCollection);
+    job.accept(ctx);
+
+    // Assert
+
+    String expected =
+        """
+                Updating final exam info for [20211]
+                Attempting to update final exams for 0 sections in MongoDB...
+                0 final exams updated, 0 errors
+                Final exam info for [20211] has been updated""";
+
+    assertEquals(expected, jobStarted.getLog());
+  }
+
+  @Test
+  void test_log_output_with_updates() throws Exception {
+
+    // Arrange
+
+    String coursePageJson = CoursePageFixtures.COURSE_PAGE_JSON_MATH3B;
+    CoursePage coursePage = CoursePage.fromJSON(coursePageJson);
+
+    List<ConvertedSection> convertedSections = coursePage.convertedSections();
+
+    List<ConvertedSection> exampleSections = new ArrayList<>();
+
+    ConvertedSection section0 = convertedSections.get(0);
+    ConvertedSection section1 = convertedSections.get(1);
+
+    exampleSections.add(section0);
+    exampleSections.add(section1);
+
+    Optional<ConvertedSection> section0Optional = Optional.of(section0);
+    Optional<ConvertedSection> emptyOptional = Optional.empty();
+
+    when(convertedSectionCollection.findByQuarterRange(
+            eq("20222"), eq("20222")))
+        .thenReturn(exampleSections);
+
+    // Act
+    var job =
+        new UpdateFinalsDataJob(
+            "20222", "20222", ucsbCurriculumService, convertedSectionCollection);
+    job.accept(ctx);
+
+    // Assert
+
+    String expected =
+        """
+                Updating final exam info for [20222]
+                Attempting to update final exams for 2 sections in MongoDB...
+                2 final exams updated, 0 errors
+                Final exam info for [20222] has been updated""";
+
+    assertEquals(expected, jobStarted.getLog());
+  }
+
+  @Test
+  void test_log_output_with_errors() throws Exception {
+
+    // Arrange
+
+    String coursePageJson = CoursePageFixtures.COURSE_PAGE_JSON_MATH3B;
+    CoursePage coursePage = CoursePage.fromJSON(coursePageJson);
+
+    List<ConvertedSection> convertedSections = coursePage.convertedSections();
+
+    List<ConvertedSection> listWithOneSection = new ArrayList<>();
+
+    ConvertedSection section0 = convertedSections.get(0);
+
+    listWithOneSection.add(section0);
+
+    when(convertedSectionCollection.findByQuarterRange(
+            eq(section0.getCourseInfo().getQuarter()), eq(section0.getCourseInfo().getQuarter())))
+        .thenReturn(listWithOneSection);
+    when(convertedSectionCollection.save( any() ))
+        .thenThrow(new IllegalArgumentException("Testing Exception Handling!"));
+
+    // Act
+    var job =
+        new UpdateFinalsDataJob(
+            "20222", "20222", ucsbCurriculumService, convertedSectionCollection);
+    job.accept(ctx);
+
+    // Assert
+
+    String expected =
+        """
+                Updating final exam info for [20222]
+                Attempting to update final exams for 1 sections in MongoDB...
+                Error saving final exam: Testing Exception Handling!
+                0 final exams updated, 1 errors
+                Final exam info for [20222] has been updated""";
+
+    assertEquals(expected, jobStarted.getLog());
+  }
+}

--- a/src/test/java/edu/ucsb/cs156/courses/jobs/UpdateFinalsDataJobTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/jobs/UpdateFinalsDataJobTests.java
@@ -1,6 +1,7 @@
 package edu.ucsb.cs156.courses.jobs;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
@@ -9,6 +10,7 @@ import edu.ucsb.cs156.courses.collections.ConvertedSectionCollection;
 import edu.ucsb.cs156.courses.documents.ConvertedSection;
 import edu.ucsb.cs156.courses.documents.CoursePage;
 import edu.ucsb.cs156.courses.documents.CoursePageFixtures;
+import edu.ucsb.cs156.courses.documents.FinalExam;
 import edu.ucsb.cs156.courses.entities.Job;
 import edu.ucsb.cs156.courses.services.UCSBCurriculumService;
 import edu.ucsb.cs156.courses.services.jobs.JobContext;
@@ -94,6 +96,10 @@ public class UpdateFinalsDataJobTests {
             eq("20222"), eq("20222")))
         .thenReturn(exampleSections);
 
+    FinalExam newFinalInfo = new FinalExam();
+    when(ucsbCurriculumService.getFinalExamObject(any(), any()))
+            .thenReturn(newFinalInfo);
+
     // Act
     var job =
         new UpdateFinalsDataJob(
@@ -110,6 +116,9 @@ public class UpdateFinalsDataJobTests {
                 Final exam info for [20222] has been updated""";
 
     assertEquals(expected, jobStarted.getLog());
+    assertNotNull(section0.getFinalExam());
+
+    verify(convertedSectionCollection, times(2)).save( any() );
   }
 
   @Test

--- a/src/test/java/edu/ucsb/cs156/courses/jobs/UpdateFinalsDataJobTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/jobs/UpdateFinalsDataJobTests.java
@@ -37,10 +37,7 @@ public class UpdateFinalsDataJobTests {
     var job =
         spy(
             new UpdateFinalsDataJob(
-                "20211",
-                "20213",
-                ucsbCurriculumService,
-                convertedSectionCollection));
+                "20211", "20213", ucsbCurriculumService, convertedSectionCollection));
     doNothing().when(job).updateFinals(any(), any());
 
     job.accept(ctx);
@@ -92,13 +89,11 @@ public class UpdateFinalsDataJobTests {
     Optional<ConvertedSection> section0Optional = Optional.of(section0);
     Optional<ConvertedSection> emptyOptional = Optional.empty();
 
-    when(convertedSectionCollection.findByQuarterRange(
-            eq("20222"), eq("20222")))
+    when(convertedSectionCollection.findByQuarterRange(eq("20222"), eq("20222")))
         .thenReturn(exampleSections);
 
     FinalExam newFinalInfo = new FinalExam();
-    when(ucsbCurriculumService.getFinalExamObject(any(), any()))
-            .thenReturn(newFinalInfo);
+    when(ucsbCurriculumService.getFinalExamObject(any(), any())).thenReturn(newFinalInfo);
 
     // Act
     var job =
@@ -118,7 +113,7 @@ public class UpdateFinalsDataJobTests {
     assertEquals(expected, jobStarted.getLog());
     assertNotNull(section0.getFinalExam());
 
-    verify(convertedSectionCollection, times(2)).save( any() );
+    verify(convertedSectionCollection, times(2)).save(any());
   }
 
   @Test
@@ -140,7 +135,7 @@ public class UpdateFinalsDataJobTests {
     when(convertedSectionCollection.findByQuarterRange(
             eq(section0.getCourseInfo().getQuarter()), eq(section0.getCourseInfo().getQuarter())))
         .thenReturn(listWithOneSection);
-    when(convertedSectionCollection.save( any() ))
+    when(convertedSectionCollection.save(any()))
         .thenThrow(new IllegalArgumentException("Testing Exception Handling!"));
 
     // Act

--- a/src/test/java/edu/ucsb/cs156/courses/services/UCSBCurriculumServiceTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/services/UCSBCurriculumServiceTests.java
@@ -13,6 +13,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import edu.ucsb.cs156.courses.documents.ConvertedSection;
 import edu.ucsb.cs156.courses.documents.CoursePageFixtures;
+import edu.ucsb.cs156.courses.documents.FinalExam;
 import edu.ucsb.cs156.courses.documents.PersonalSectionsFixtures;
 import edu.ucsb.cs156.courses.documents.SectionFixtures;
 import java.util.List;
@@ -429,7 +430,7 @@ public class UCSBCurriculumServiceTests {
     String expectedResult = "{expectedResult}";
 
     String enrollCd = "04051";
-    String quarter = "";
+    String quarter = "20241";
 
     String expectedParams = String.format("?quarter=%s&enrollCode=%s", quarter, enrollCd);
     String expectedURL = UCSBCurriculumService.FINALS_ENDPOINT + expectedParams;
@@ -452,7 +453,7 @@ public class UCSBCurriculumServiceTests {
     String expectedResult = "{\"error\": \"401: Unauthorized\"}";
 
     String enrollCd = "04051";
-    String quarter = "20241";
+    String quarter = "";
 
     String expectedParams = String.format("?quarter=%s&enrollCode=%s", quarter, enrollCd);
     String expectedURL = UCSBCurriculumService.FINALS_ENDPOINT + expectedParams;
@@ -495,5 +496,29 @@ public class UCSBCurriculumServiceTests {
     String result = ucs.getFinalExamInfo(quarter, enrollCd);
 
     assertEquals(expectedResult, result);
+  }
+
+  @Test
+  public void test_getFinalExamObject_success() throws Exception {
+    String expectedResult = "{}";
+
+    String enrollCd = "04051";
+    String quarter = "20241";
+
+    String expectedParams = String.format("?quarter=%s&enrollCode=%s", quarter, enrollCd);
+    String expectedURL = UCSBCurriculumService.FINALS_ENDPOINT + expectedParams;
+
+    this.mockRestServiceServer
+        .expect(requestTo(expectedURL))
+        .andExpect(header("Accept", MediaType.APPLICATION_JSON.toString()))
+        .andExpect(header("Content-Type", MediaType.APPLICATION_JSON.toString()))
+        .andExpect(header("ucsb-api-version", "1.0"))
+        .andExpect(header("ucsb-api-key", apiKey))
+        .andRespond(withSuccess(expectedResult, MediaType.APPLICATION_JSON));
+
+    FinalExam result = ucs.getFinalExamObject(quarter, enrollCd);
+
+    ObjectMapper objectMapper = new ObjectMapper();
+    assertEquals(objectMapper.readValue(expectedResult, FinalExam.class), result);
   }
 }


### PR DESCRIPTION
Closes #25 

**This should not be merged until #27 is approved and merged.**

In this PR we add a backend job to update courses in the MongoDB database by quarter, inserting their final exam info. In addition to the "courseInfo" and "section" fields that are stored in the database, this job adds a "finalExam" field according to the final exam info format from #27. 

The job endpoint can be tested at https://proj-courses-irreflexive-dev.dokku-09.cs.ucsb.edu/swagger-ui/index.html under /api/jobs/launch/updateFinalsData

The job submission form has been assigned its own issue (#28). For now, the jobs page looks like this:
![image](https://github.com/ucsb-cs156-f23/proj-courses-f23-7pm-1/assets/33270232/c27d3b36-3766-48f3-869b-94b681f91ef8)