### PR TITLE
Added section number column to search by course instructor. 

### DIFF
--- a/frontend/src/main/components/Sections/SectionsTable.js
+++ b/frontend/src/main/components/Sections/SectionsTable.js
@@ -1,6 +1,7 @@
 import SectionsTableBase from "main/components/SectionsTableBase";
 
 import { yyyyqToQyy } from "main/utils/quarterUtilities.js";
+
 import {
   convertToFraction,
   formatDays,

--- a/frontend/src/main/components/Sections/SectionsTable.js
+++ b/frontend/src/main/components/Sections/SectionsTable.js
@@ -85,13 +85,13 @@ export default function SectionsTable({ sections }) {
       Aggregated: ({ cell: { value } }) => `${value}`,
     },
     {
-    Header: "Section Number",
-    accessor: (row) => row.section.section,
-    // Stryker disable next-line StringLiteral: this column is hidden, very hard to test
-    id: "sectionNumber",
-    aggregate: getFirstVal,
-    Aggregated: ({ cell: { value } }) => `${value}`,
-  },
+      Header: "Section Number",
+      accessor: (row) => row.section.section,
+      // Stryker disable next-line StringLiteral: this column is hidden, very hard to test
+      id: "sectionNumber",
+      aggregate: getFirstVal,
+      Aggregated: ({ cell: { value } }) => `${value}`,
+    },
     {
       Header: "Days",
       accessor: (row) => formatDays(row.section.timeLocations),

--- a/frontend/src/main/components/Sections/SectionsTable.js
+++ b/frontend/src/main/components/Sections/SectionsTable.js
@@ -15,6 +15,7 @@ import {
 } from "main/utils/sectionUtils.js";
 
 function getFirstVal(values) {
+  //Get first value
   return values[0];
 }
 

--- a/frontend/src/main/components/Sections/SectionsTable.js
+++ b/frontend/src/main/components/Sections/SectionsTable.js
@@ -85,6 +85,14 @@ export default function SectionsTable({ sections }) {
       Aggregated: ({ cell: { value } }) => `${value}`,
     },
     {
+    Header: "Section Number",
+    accessor: (row) => row.section.section,
+    // Stryker disable next-line StringLiteral: this column is hidden, very hard to test
+    id: "sectionNumber",
+    aggregate: getFirstVal,
+    Aggregated: ({ cell: { value } }) => `${value}`,
+  },
+    {
       Header: "Days",
       accessor: (row) => formatDays(row.section.timeLocations),
       disableGroupBy: true,

--- a/frontend/src/main/components/Sections/SectionsTable.js
+++ b/frontend/src/main/components/Sections/SectionsTable.js
@@ -13,6 +13,7 @@ import {
   isSectionClosed,
   isSectionFull,
 } from "main/utils/sectionUtils.js";
+import { Button } from "react-bootstrap";
 
 function getFirstVal(values) {
   //Get first value
@@ -128,6 +129,25 @@ export default function SectionsTable({ sections }) {
 
       aggregate: getFirstVal,
       Aggregated: ({ cell: { value } }) => `${value}`,
+    },
+    {
+      Header: "Info",
+      accessor: (row) =>
+        `/coursedetails/${row.courseInfo.quarter}/${row.section.enrollCode}`,
+      disableGroupBy: true,
+      id: "info",
+
+      aggregate: getFirstVal,
+      Cell: ({ cell: { value } }) => (
+        <Button variant="outline-dark" size="sm" href={value}>
+          ⓘ
+        </Button>
+      ),
+      Aggregated: ({ cell: { value } }) => (
+        <Button variant="outline-light" size="sm" href={value}>
+          ⓘ
+        </Button>
+      ),
     },
   ];
 

--- a/frontend/src/main/components/SectionsTableBase.js
+++ b/frontend/src/main/components/SectionsTableBase.js
@@ -14,7 +14,7 @@ export default function SectionsTableBase({
       {
         initialState: {
           groupBy: ["courseInfo.courseId"],
-          hiddenColumns: ["isSection"],
+          hiddenColumns: [],
         },
         columns,
         data,

--- a/frontend/src/tests/components/Sections/SectionsTable.test.js
+++ b/frontend/src/tests/components/Sections/SectionsTable.test.js
@@ -116,7 +116,8 @@ describe("Section tests", () => {
       "Days",
       "Time",
       "Instructor",
-      "Enroll Code",
+      "Enroll Code", 
+      "Section Number"
     ];
     const expectedFields = [
       "quarter",
@@ -129,6 +130,7 @@ describe("Section tests", () => {
       "time",
       "instructor",
       "section.enrollCode",
+      "sectionNumber"
     ];
     const testId = "SectionsTable";
 
@@ -150,6 +152,9 @@ describe("Section tests", () => {
     expect(
       screen.getByTestId(`${testId}-cell-row-0-col-quarter`),
     ).toHaveTextContent("W22");
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-sectionNumber`),
+    ).toHaveTextContent("0100");
     expect(
       screen.getByTestId(`${testId}-cell-row-0-col-time`),
     ).toHaveTextContent("3:00 PM - 3:50 PM");
@@ -254,4 +259,35 @@ describe("Section tests", () => {
       screen.getByTestId(`${testId}-cell-row-3-col-status`),
     ).toHaveTextContent("CANCELLED");
   });
+  test("Sections have appropriate section number columns", () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <SectionsTable sections={fiveSections} />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    const testId = "SectionsTable";
+
+    const expandRow = screen.getByTestId(
+      `${testId}-cell-row-1-col-courseInfo.courseId-expand-symbols`,
+    );
+    fireEvent.click(expandRow);
+
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-status`),
+    ).toHaveTextContent("OPEN");
+    expect(
+      screen.getByTestId(`${testId}-cell-row-1-col-status`),
+    ).toHaveTextContent("CLOSED");
+    expect(
+      screen.getByTestId(`${testId}-cell-row-2-col-status`),
+    ).toHaveTextContent("FULL");
+    expect(
+      screen.getByTestId(`${testId}-cell-row-3-col-status`),
+    ).toHaveTextContent("CANCELLED");
+  });
 });
+
+

--- a/frontend/src/tests/components/Sections/SectionsTable.test.js
+++ b/frontend/src/tests/components/Sections/SectionsTable.test.js
@@ -116,8 +116,8 @@ describe("Section tests", () => {
       "Days",
       "Time",
       "Instructor",
-      "Enroll Code", 
-      "Section Number"
+      "Enroll Code",
+      "Section Number",
     ];
     const expectedFields = [
       "quarter",
@@ -130,7 +130,7 @@ describe("Section tests", () => {
       "time",
       "instructor",
       "section.enrollCode",
-      "sectionNumber"
+      "sectionNumber",
     ];
     const testId = "SectionsTable";
 
@@ -289,5 +289,3 @@ describe("Section tests", () => {
     ).toHaveTextContent("CANCELLED");
   });
 });
-
-

--- a/frontend/src/tests/components/Sections/SectionsTable.test.js
+++ b/frontend/src/tests/components/Sections/SectionsTable.test.js
@@ -44,6 +44,7 @@ describe("Section tests", () => {
       "Time",
       "Instructor",
       "Enroll Code",
+      "Info",
     ];
     const expectedFields = [
       "quarter",
@@ -56,6 +57,7 @@ describe("Section tests", () => {
       "time",
       "instructor",
       "section.enrollCode",
+      "info",
     ];
     const testId = "SectionsTable";
 
@@ -95,6 +97,9 @@ describe("Section tests", () => {
     expect(
       screen.getByTestId(`${testId}-cell-row-2-col-instructor`),
     ).toHaveTextContent("YUNG A S");
+    expect(
+      screen.getByTestId(`${testId}-cell-row-2-col-info`).children[0],
+    ).toHaveTextContent("ⓘ");
   });
 
   test("Has the expected column headers and content", async () => {
@@ -117,7 +122,10 @@ describe("Section tests", () => {
       "Time",
       "Instructor",
       "Enroll Code",
+
       "Section Number",
+
+      "Info",
     ];
     const expectedFields = [
       "quarter",
@@ -131,6 +139,7 @@ describe("Section tests", () => {
       "instructor",
       "section.enrollCode",
       "sectionNumber",
+      "info",
     ];
     const testId = "SectionsTable";
 
@@ -176,6 +185,12 @@ describe("Section tests", () => {
     expect(
       screen.getByTestId(`${testId}-cell-row-0-col-section.enrollCode`),
     ).toHaveTextContent("12583");
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-info`).children[0],
+    ).toHaveTextContent("ⓘ");
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-info`).children[0].href,
+    ).toMatch(/\/coursedetails\/20221\/12583$/);
   });
 
   test("Correctly groups separate lectures of the same class", async () => {


### PR DESCRIPTION
In the search by course instructor section table, it adds a section number column.  Closes #33 
<img width="837" alt="Screenshot 2023-11-28 at 11 58 16 AM" src="https://github.com/ucsb-cs156-f23/proj-courses-f23-7pm-1/assets/91993150/0696a644-a247-4b99-b542-87af02930979">
As we see in this table above, Professor Conrad's last two digits of his section number are 00, indicating that Professor Conrad teaches a course. On the other hand, in this screenshot below, a ta who only teaches a section will have the last two digits of the second number not as 00. This can help identify different sections and help distinguish between sections and lectures in the table. 
<img width="1122" alt="Screenshot 2023-11-28 at 12 05 15 PM" src="https://github.com/ucsb-cs156-f23/proj-courses-f23-7pm-1/assets/91993150/57f62ee6-ee09-48a0-a9c5-94def5c76c7e">
https://proj-courses-madhav-ucsb-dev.dokku-09.cs.ucsb.edu/courseovertime/instructorsearch
