### PR TITLE
Added Dropdown to choose Schedule to Add Course

### DIFF
--- a/frontend/src/main/components/Courses/CourseForm.js
+++ b/frontend/src/main/components/Courses/CourseForm.js
@@ -3,6 +3,7 @@ import { Button, Form } from "react-bootstrap";
 import { useForm } from "react-hook-form";
 import { useNavigate } from "react-router-dom";
 import PersonalScheduleDropdown from "../PersonalSchedules/PersonalScheduleDropdown.js";
+import { useBackend } from "main/utils/useBackend";
 
 function CourseForm({ initialCourse, submitAction, buttonLabel = "Create" }) {
   // Stryker disable all
@@ -15,11 +16,16 @@ function CourseForm({ initialCourse, submitAction, buttonLabel = "Create" }) {
 
   const navigate = useNavigate();
 
-  // Dummy schedule data
-  const schedules = [
-    { id: 1, quarter: "20213", name: "Placeholder Schedule 1" },
-    { id: 2, quarter: "20223", name: "Placeholder Schedule 2" },
-  ];
+  const {
+    data: schedules,
+    error: _error,
+    status: _status,
+  } = useBackend(
+    // Stryker disable next-line all : don't test internal caching of React Query
+    ["/api/personalschedules/all"],
+    { method: "GET", url: "/api/personalschedules/all" },
+    [],
+  );
 
   return (
     <Form onSubmit={handleSubmit(submitAction)}>

--- a/frontend/src/main/components/Courses/CourseForm.js
+++ b/frontend/src/main/components/Courses/CourseForm.js
@@ -2,6 +2,7 @@ import React from "react";
 import { Button, Form } from "react-bootstrap";
 import { useForm } from "react-hook-form";
 import { useNavigate } from "react-router-dom";
+import PersonalScheduleDropdown from "../PersonalSchedules/PersonalScheduleDropdown.js";
 
 function CourseForm({ initialCourse, submitAction, buttonLabel = "Create" }) {
   // Stryker disable all
@@ -13,6 +14,12 @@ function CourseForm({ initialCourse, submitAction, buttonLabel = "Create" }) {
   // Stryker enable all
 
   const navigate = useNavigate();
+
+  // Dummy schedule data
+  const schedules = [
+    { id: 1, quarter: "20213", name: "Placeholder Schedule 1" },
+    { id: 2, quarter: "20223", name: "Placeholder Schedule 2" },
+  ];
 
   return (
     <Form onSubmit={handleSubmit(submitAction)}>
@@ -46,7 +53,7 @@ function CourseForm({ initialCourse, submitAction, buttonLabel = "Create" }) {
         </Form.Control.Feedback>
       </Form.Group>
 
-      <Form.Group className="mb-3">
+      {/* <Form.Group className="mb-3">
         <Form.Label htmlFor="psId">Personal Schedule ID</Form.Label>
         <Form.Control
           data-testid="CourseForm-psId"
@@ -60,6 +67,16 @@ function CourseForm({ initialCourse, submitAction, buttonLabel = "Create" }) {
         <Form.Control.Feedback type="invalid">
           {errors.psId?.message}
         </Form.Control.Feedback>
+      </Form.Group> */}
+
+      <Form.Group className="mb-3">
+        <PersonalScheduleDropdown
+          schedules={schedules}
+          schedule={initialCourse ? initialCourse.psId : ""} // Pass the initial value if available
+          setSchedule={(selectedSchedule) => register("psId").onChange(selectedSchedule)} // Update the form value
+          controlId="psIdDropdown" // Unique identifier for the dropdown
+          label="Schedule"
+        />
       </Form.Group>
 
       <Button type="submit" data-testid="CourseForm-submit">

--- a/frontend/src/main/components/Courses/CourseForm.js
+++ b/frontend/src/main/components/Courses/CourseForm.js
@@ -1,11 +1,9 @@
 import React from "react";
-// import { useEffect } from "react";
 import { Button, Form } from "react-bootstrap";
 import { useForm } from "react-hook-form";
 import { useNavigate } from "react-router-dom";
 import PersonalScheduleDropdown from "../PersonalSchedules/PersonalScheduleDropdown.js";
 import { useBackend } from "main/utils/useBackend";
-
 
 function CourseForm({ initialCourse, controlId, submitAction, scheduleState, setScheduleState, buttonLabel = "Create" }) {
   // Stryker disable all
@@ -28,7 +26,6 @@ function CourseForm({ initialCourse, controlId, submitAction, scheduleState, set
     { method: "GET", url: "/api/personalschedules/all" },
     [],
   );
-
 
   return (
     <Form onSubmit={handleSubmit(submitAction)}>

--- a/frontend/src/main/components/Courses/CourseForm.js
+++ b/frontend/src/main/components/Courses/CourseForm.js
@@ -3,29 +3,53 @@ import { Button, Form } from "react-bootstrap";
 import { useForm } from "react-hook-form";
 import { useNavigate } from "react-router-dom";
 import PersonalScheduleDropdown from "../PersonalSchedules/PersonalScheduleDropdown.js";
-import { useBackend } from "main/utils/useBackend";
+import { useBackend } from "main/utils/useBackend.js";
+import { useState } from "react";
+import { useMemo } from "react";
 
-function CourseForm({ initialCourse, controlId, submitAction, scheduleState, setScheduleState, buttonLabel = "Create" }) {
+function CourseForm({ initialCourse, submitAction, buttonLabel = "Create" }) {
   // Stryker disable all
-  const {
-    register,
-    formState: { errors },
-    handleSubmit,
-  } = useForm({ defaultValues: initialCourse || {} });
-  // Stryker enable all
-
-  const navigate = useNavigate();
-
   const {
     data: schedules,
     error: _error,
     status: _status,
   } = useBackend(
-    // Stryker disable next-line all 
     ["/api/personalschedules/all"],
     { method: "GET", url: "/api/personalschedules/all" },
     [],
   );
+
+  const memoCourse = useMemo(() => { return {psId: schedules[0]?.id} }, [schedules]);
+  
+  const {
+    register,
+    formState: { errors },
+    handleSubmit,
+  } = useForm({ defaultValues: initialCourse || memoCourse });
+  // Stryker enable all
+
+  const navigate = useNavigate();
+
+  const controlId = "CourseForm-psId";
+
+  // if (schedules.length > 0 && localStorage.getItem(controlId) == null) {
+  //   localStorage.setItem(controlId, schedules[0].id);
+  // }
+
+  const localSearchSchedule = localStorage.getItem(controlId);
+
+  const [scheduleState, setScheduleState] = useState(
+    // Stryker disable next-line all : not sure how to test/mock local storage
+    localSearchSchedule || "",
+  );
+
+  if (schedules.length > 0) {
+    localStorage.setItem(controlId, schedules[0].id);
+  }
+
+  if (scheduleState) {
+    localStorage.setItem(controlId, scheduleState);
+  }
 
   return (
     <Form onSubmit={handleSubmit(submitAction)}>
@@ -59,11 +83,11 @@ function CourseForm({ initialCourse, controlId, submitAction, scheduleState, set
         </Form.Control.Feedback>
       </Form.Group>
 
-      <Form.Group className="mb-3">
+      <Form.Group className="mb-3" data-testid="CourseForm-psId">
         <PersonalScheduleDropdown
           schedules={schedules}
-          scheduleState={scheduleState}
-          setScheduleState={setScheduleState}
+          schedule={scheduleState}
+          setSchedule={setScheduleState}
           controlId={controlId}
         />
       </Form.Group>

--- a/frontend/src/main/components/Courses/CourseForm.js
+++ b/frontend/src/main/components/Courses/CourseForm.js
@@ -1,11 +1,13 @@
 import React from "react";
+// import { useEffect } from "react";
 import { Button, Form } from "react-bootstrap";
 import { useForm } from "react-hook-form";
 import { useNavigate } from "react-router-dom";
 import PersonalScheduleDropdown from "../PersonalSchedules/PersonalScheduleDropdown.js";
 import { useBackend } from "main/utils/useBackend";
 
-function CourseForm({ initialCourse, submitAction, buttonLabel = "Create" }) {
+
+function CourseForm({ initialCourse, controlId, submitAction, scheduleState, setScheduleState, buttonLabel = "Create" }) {
   // Stryker disable all
   const {
     register,
@@ -21,11 +23,12 @@ function CourseForm({ initialCourse, submitAction, buttonLabel = "Create" }) {
     error: _error,
     status: _status,
   } = useBackend(
-    // Stryker disable next-line all : don't test internal caching of React Query
+    // Stryker disable next-line all 
     ["/api/personalschedules/all"],
     { method: "GET", url: "/api/personalschedules/all" },
     [],
   );
+
 
   return (
     <Form onSubmit={handleSubmit(submitAction)}>
@@ -59,29 +62,12 @@ function CourseForm({ initialCourse, submitAction, buttonLabel = "Create" }) {
         </Form.Control.Feedback>
       </Form.Group>
 
-      {/* <Form.Group className="mb-3">
-        <Form.Label htmlFor="psId">Personal Schedule ID</Form.Label>
-        <Form.Control
-          data-testid="CourseForm-psId"
-          id="psId"
-          type="text"
-          isInvalid={Boolean(errors.psId)}
-          {...register("psId", {
-            required: "Personal Schedule ID is required.",
-          })}
-        />
-        <Form.Control.Feedback type="invalid">
-          {errors.psId?.message}
-        </Form.Control.Feedback>
-      </Form.Group> */}
-
       <Form.Group className="mb-3">
         <PersonalScheduleDropdown
           schedules={schedules}
-          schedule={initialCourse ? initialCourse.psId : ""} // Pass the initial value if available
-          setSchedule={(selectedSchedule) => register("psId").onChange(selectedSchedule)} // Update the form value
-          controlId="psIdDropdown" // Unique identifier for the dropdown
-          label="Schedule"
+          scheduleState={scheduleState}
+          setScheduleState={setScheduleState}
+          controlId={controlId}
         />
       </Form.Group>
 

--- a/frontend/src/main/components/PersonalSchedules/PersonalScheduleDropdown.js
+++ b/frontend/src/main/components/PersonalSchedules/PersonalScheduleDropdown.js
@@ -1,21 +1,27 @@
-import React from "react";
+import React, { useState } from "react";
 import { Form } from "react-bootstrap";
 import { yyyyqToQyy } from "main/utils/quarterUtilities.js";
- 
+
 const PersonalScheduleDropdown = ({
   schedules,
-  scheduleState,
-  setScheduleState,
+  schedule,
+  setSchedule,
   controlId,
   onChange = null,
   label = "Schedule",
 }) => {
+  const localSearchSchedule = localStorage.getItem(controlId);
+
+  const [scheduleState, setScheduleState] = useState(
+    // Stryker disable next-line all : not sure how to test/mock local storage
+    localSearchSchedule || schedule,
+  );
 
   const handleScheduleOnChange = (event) => {
-    // console.log("event = ", event);
     const selectedSchedule = event.target.value;
     localStorage.setItem(controlId, selectedSchedule);
     setScheduleState(selectedSchedule);
+    setSchedule(selectedSchedule);
     if (onChange != null) {
       onChange(event);
     }

--- a/frontend/src/main/components/PersonalSchedules/PersonalScheduleDropdown.js
+++ b/frontend/src/main/components/PersonalSchedules/PersonalScheduleDropdown.js
@@ -1,27 +1,21 @@
-import React, { useState } from "react";
+import React from "react";
 import { Form } from "react-bootstrap";
 import { yyyyqToQyy } from "main/utils/quarterUtilities.js";
 
 const PersonalScheduleDropdown = ({
   schedules,
-  schedule,
-  setSchedule,
+  scheduleState,
+  setScheduleState,
   controlId,
   onChange = null,
   label = "Schedule",
 }) => {
-  const localSearchSchedule = localStorage.getItem(controlId);
-
-  const [scheduleState, setScheduleState] = useState(
-    // Stryker disable next-line all : not sure how to test/mock local storage
-    localSearchSchedule || schedule,
-  );
 
   const handleScheduleOnChange = (event) => {
+    // console.log("event = ", event);
     const selectedSchedule = event.target.value;
     localStorage.setItem(controlId, selectedSchedule);
     setScheduleState(selectedSchedule);
-    setSchedule(selectedSchedule);
     if (onChange != null) {
       onChange(event);
     }

--- a/frontend/src/main/components/PersonalSchedules/PersonalScheduleDropdown.js
+++ b/frontend/src/main/components/PersonalSchedules/PersonalScheduleDropdown.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { Form } from "react-bootstrap";
 import { yyyyqToQyy } from "main/utils/quarterUtilities.js";
-
+ 
 const PersonalScheduleDropdown = ({
   schedules,
   scheduleState,

--- a/frontend/src/main/components/PersonalSchedules/PersonalSchedulesTable.js
+++ b/frontend/src/main/components/PersonalSchedules/PersonalSchedulesTable.js
@@ -29,10 +29,15 @@ export default function PersonalSchedulesTable({
   );
   // Stryker enable all
 
-  // Stryker disable next-line all : TODO try to make a good test for this
+  // Stryker disable all : TODO try to make a good test for this
   const deleteCallback = async (cell) => {
     deleteMutation.mutate(cell);
+    const id = String(cell.row.values.id);
+    if (localStorage["CourseForm-psId"] === id) {
+      localStorage.removeItem("CourseForm-psId");
+    }
   };
+  // Stryker enable all
 
   const columns = [
     {

--- a/frontend/src/main/pages/Courses/PSCourseCreatePage.js
+++ b/frontend/src/main/pages/Courses/PSCourseCreatePage.js
@@ -15,12 +15,12 @@ export default function CoursesCreatePage() {
     },
   });
 
-  const controlId = "CoursesCreatePage";
+  const controlId = "CourseCreatePage";
   const localSearchSchedule = localStorage.getItem(controlId);
 
   const [scheduleState, setScheduleState] = useState(
     // Stryker disable next-line all : not sure how to test/mock local storage
-    localSearchSchedule || "",
+    localSearchSchedule || "0",
   );
 
   const onSuccess = (course) => {

--- a/frontend/src/main/pages/Courses/PSCourseCreatePage.js
+++ b/frontend/src/main/pages/Courses/PSCourseCreatePage.js
@@ -3,7 +3,6 @@ import CourseForm from "main/components/Courses/CourseForm";
 import { Navigate } from "react-router-dom";
 import { useBackendMutation } from "main/utils/useBackend";
 import { toast } from "react-toastify";
-import { useState } from "react";
 
 export default function CoursesCreatePage() {
   const objectToAxiosParams = (course) => ({
@@ -11,17 +10,9 @@ export default function CoursesCreatePage() {
     method: "POST",
     params: {
       enrollCd: course.enrollCd,
-      psId: scheduleState,
+      psId: course.psId,
     },
   });
-
-  const controlId = "CourseCreatePage";
-  const localSearchSchedule = localStorage.getItem(controlId);
-
-  const [scheduleState, setScheduleState] = useState(
-    // Stryker disable next-line all : not sure how to test/mock local storage
-    localSearchSchedule || "0",
-  );
 
   const onSuccess = (course) => {
     toast(`New course Created - id: ${course.id} enrollCd: ${course.enrollCd}`);
@@ -37,8 +28,12 @@ export default function CoursesCreatePage() {
   const { isSuccess } = mutation;
 
   const onSubmit = async (data) => {
-    // console.log("scheduleState = ", scheduleState)
-    mutation.mutate(data);
+    const psId = {
+      psId: localStorage["CourseForm-psId"],
+    };
+    const dataFinal = Object.assign(data, psId);
+    console.log(dataFinal);
+    mutation.mutate(dataFinal);
   };
 
   if (isSuccess) {
@@ -50,7 +45,7 @@ export default function CoursesCreatePage() {
         <div className="pt-2">
           <h1>Create New Course</h1>
 
-          <CourseForm submitAction={onSubmit} controlId={controlId} scheduleState={scheduleState} setScheduleState={setScheduleState} />
+          <CourseForm submitAction={onSubmit} />
           <p data-testid="PSCourseCreate-Error">
             Error: {mutation.error.response.data?.message}
           </p>

--- a/frontend/src/main/pages/Courses/PSCourseCreatePage.js
+++ b/frontend/src/main/pages/Courses/PSCourseCreatePage.js
@@ -3,6 +3,7 @@ import CourseForm from "main/components/Courses/CourseForm";
 import { Navigate } from "react-router-dom";
 import { useBackendMutation } from "main/utils/useBackend";
 import { toast } from "react-toastify";
+import { useState } from "react";
 
 export default function CoursesCreatePage() {
   const objectToAxiosParams = (course) => ({
@@ -10,9 +11,17 @@ export default function CoursesCreatePage() {
     method: "POST",
     params: {
       enrollCd: course.enrollCd,
-      psId: course.psId,
+      psId: scheduleState,
     },
   });
+
+  const controlId = "CoursesCreatePage";
+  const localSearchSchedule = localStorage.getItem(controlId);
+
+  const [scheduleState, setScheduleState] = useState(
+    // Stryker disable next-line all : not sure how to test/mock local storage
+    localSearchSchedule || "",
+  );
 
   const onSuccess = (course) => {
     toast(`New course Created - id: ${course.id} enrollCd: ${course.enrollCd}`);
@@ -28,6 +37,7 @@ export default function CoursesCreatePage() {
   const { isSuccess } = mutation;
 
   const onSubmit = async (data) => {
+    // console.log("scheduleState = ", scheduleState)
     mutation.mutate(data);
   };
 
@@ -40,7 +50,7 @@ export default function CoursesCreatePage() {
         <div className="pt-2">
           <h1>Create New Course</h1>
 
-          <CourseForm submitAction={onSubmit} />
+          <CourseForm submitAction={onSubmit} controlId={controlId} scheduleState={scheduleState} setScheduleState={setScheduleState} />
           <p data-testid="PSCourseCreate-Error">
             Error: {mutation.error.response.data?.message}
           </p>

--- a/frontend/src/tests/components/Courses/CourseForm.test.js
+++ b/frontend/src/tests/components/Courses/CourseForm.test.js
@@ -19,7 +19,7 @@ describe("CourseForm tests", () => {
       </Router>,
     );
 
-    expect(await screen.findByText(/Personal Schedule ID/)).toBeInTheDocument();
+    expect(await screen.findByText(/Schedule/)).toBeInTheDocument();
     expect(screen.getByText(/Enrollment Code/)).toBeInTheDocument();
     expect(screen.getByText(/Create/)).toBeInTheDocument();
   });

--- a/frontend/src/tests/components/Courses/CourseForm.test.js
+++ b/frontend/src/tests/components/Courses/CourseForm.test.js
@@ -1,6 +1,6 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { BrowserRouter as Router } from "react-router-dom";
-
+import { QueryClient, QueryClientProvider } from "react-query";
 import CourseForm from "main/components/Courses/CourseForm";
 import { coursesFixtures } from "fixtures/pscourseFixtures";
 
@@ -13,10 +13,13 @@ jest.mock("react-router-dom", () => ({
 
 describe("CourseForm tests", () => {
   test("renders correctly", async () => {
+    const queryClient = new QueryClient();
     render(
-      <Router>
-        <CourseForm />
-      </Router>,
+      <QueryClientProvider client={queryClient}>
+        <Router>
+          <CourseForm />
+        </Router>
+      </QueryClientProvider>,
     );
 
     expect(await screen.findByText(/Schedule/)).toBeInTheDocument();
@@ -25,10 +28,13 @@ describe("CourseForm tests", () => {
   });
 
   test("renders correctly when passing in a Course", async () => {
+    const queryClient = new QueryClient();
     render(
-      <Router>
-        <CourseForm initialCourse={coursesFixtures.oneCourse} />
-      </Router>,
+      <QueryClientProvider client={queryClient}>
+        <Router>
+          <CourseForm initialCourse={coursesFixtures.oneCourse} />
+        </Router>
+      </QueryClientProvider>,
     );
 
     expect(await screen.findByTestId(/CourseForm-id/)).toBeInTheDocument();
@@ -37,10 +43,13 @@ describe("CourseForm tests", () => {
   });
 
   test("Correct Error messages on missing input", async () => {
+    const queryClient = new QueryClient();
     render(
-      <Router>
-        <CourseForm />
-      </Router>,
+      <QueryClientProvider client={queryClient}>
+        <Router>
+          <CourseForm />
+        </Router>
+      </QueryClientProvider>,
     );
     expect(await screen.findByTestId("CourseForm-submit")).toBeInTheDocument();
     const submitButton = screen.getByTestId("CourseForm-submit");
@@ -48,23 +57,24 @@ describe("CourseForm tests", () => {
     fireEvent.click(submitButton);
 
     expect(
-      await screen.findByText(/Personal Schedule ID is required./),
+      await screen.findByText(/Enroll Code is required./),
     ).toBeInTheDocument();
-    expect(screen.getByText(/Enroll Code is required./)).toBeInTheDocument();
   });
 
   test("No Error messages on good input", async () => {
     const mockSubmitAction = jest.fn();
-
+    const queryClient = new QueryClient();
     render(
-      <Router>
-        <CourseForm submitAction={mockSubmitAction} />
-      </Router>,
+      <QueryClientProvider client={queryClient}>
+        <Router>
+          <CourseForm submitAction={mockSubmitAction} />
+        </Router>
+      </QueryClientProvider>,
     );
 
     expect(await screen.findByTestId("CourseForm-psId")).toBeInTheDocument();
 
-    const psId = screen.getByTestId("CourseForm-psId");
+    const psId = document.querySelector("#CourseForm-psId");
     const enrollCd = screen.getByTestId("CourseForm-enrollCd");
     const submitButton = screen.getByTestId("CourseForm-submit");
 
@@ -84,10 +94,13 @@ describe("CourseForm tests", () => {
   });
 
   test("that navigate(-1) is called when Cancel is clicked", async () => {
+    const queryClient = new QueryClient();
     render(
-      <Router>
-        <CourseForm />
-      </Router>,
+      <QueryClientProvider client={queryClient}>
+        <Router>
+          <CourseForm />
+        </Router>
+      </QueryClientProvider>,
     );
     expect(await screen.findByTestId("CourseForm-cancel")).toBeInTheDocument();
     const cancelButton = screen.getByTestId("CourseForm-cancel");

--- a/frontend/src/tests/components/PersonalSchedules/PersonalScheduleDropdown.test.js
+++ b/frontend/src/tests/components/PersonalSchedules/PersonalScheduleDropdown.test.js
@@ -37,8 +37,8 @@ describe("SingleSubjectDropdown tests", () => {
     render(
       <PersonalScheduleDropdown
         schedules={personalScheduleFixtures.onePersonalSchedule}
-        scheduleState={personalScheduleFixtures.onePersonalSchedule}
-        setScheduleState={setSchedule}
+        schedule={personalScheduleFixtures.onePersonalSchedule}
+        setSchedule={setSchedule}
         controlId="psd1"
       />,
     );
@@ -48,8 +48,8 @@ describe("SingleSubjectDropdown tests", () => {
     render(
       <PersonalScheduleDropdown
         schedules={personalScheduleFixtures.threePersonalSchedules}
-        scheduleState={schedule}
-        setscheduleState={setSchedule}
+        schedule={schedule}
+        setschedule={setSchedule}
         controlId="psd2"
       />,
     );
@@ -59,8 +59,8 @@ describe("SingleSubjectDropdown tests", () => {
     render(
       <PersonalScheduleDropdown
         schedules={personalScheduleFixtures.threePersonalSchedules}
-        scheduleState={schedule}
-        setscheduleState={setSchedule}
+        schedule={schedule}
+        setSchedule={setSchedule}
         controlId="psd3"
       />,
     );
@@ -75,8 +75,8 @@ describe("SingleSubjectDropdown tests", () => {
     render(
       <PersonalScheduleDropdown
         schedules={personalScheduleFixtures.threePersonalSchedules}
-        scheduleState={schedule}
-        setScheduleState={setSchedule}
+        schedule={schedule}
+        setSchedule={setSchedule}
         controlId="psd1"
         onChange={onChange}
       />,
@@ -97,8 +97,8 @@ describe("SingleSubjectDropdown tests", () => {
     render(
       <PersonalScheduleDropdown
         schedules={personalScheduleFixtures.threePersonalSchedules}
-        scheduleState={schedule}
-        setScheduleState={setSchedule}
+        schedule={schedule}
+        setSchedule={setSchedule}
         controlId="psd1"
       />,
     );
@@ -110,8 +110,8 @@ describe("SingleSubjectDropdown tests", () => {
     render(
       <PersonalScheduleDropdown
         schedules={personalScheduleFixtures.threePersonalSchedules}
-        scheduleState={schedule}
-        setScheduleState={setSchedule}
+        schedule={schedule}
+        setSchedule={setSchedule}
         controlId="psd1"
       />,
     );
@@ -124,14 +124,14 @@ describe("SingleSubjectDropdown tests", () => {
     const getItemSpy = jest.spyOn(Storage.prototype, "getItem");
     getItemSpy.mockImplementation(() => "1");
 
-    const setScheduleStateSpy = jest.fn();
-    useState.mockImplementation((x) => [x, setScheduleStateSpy]);
+    const setScheduleSpy = jest.fn();
+    useState.mockImplementation((x) => [x, setScheduleSpy]);
 
     render(
       <PersonalScheduleDropdown
         schedules={personalScheduleFixtures.threePersonalSchedules}
-        scheduleState={schedule}
-        setScheduleState={setSchedule}
+        schedule={schedule}
+        setSchedule={setSchedule}
         controlId="psd1"
       />,
     );
@@ -143,14 +143,14 @@ describe("SingleSubjectDropdown tests", () => {
     const getItemSpy = jest.spyOn(Storage.prototype, "getItem");
     getItemSpy.mockImplementation(() => null);
 
-    const setScheduleStateSpy = jest.fn();
-    useState.mockImplementation((x) => [x, setScheduleStateSpy]);
+    const setScheduleSpy = jest.fn();
+    useState.mockImplementation((x) => [x, setScheduleSpy]);
 
     render(
       <PersonalScheduleDropdown
         schedules={personalScheduleFixtures.threePersonalSchedules}
-        scheduleState={schedule}
-        setScheduleState={setSchedule}
+        schedule={schedule}
+        setSchedule={setSchedule}
         controlId="psd1"
       />,
     );
@@ -164,8 +164,8 @@ describe("SingleSubjectDropdown tests", () => {
     render(
       <PersonalScheduleDropdown
         schedules={[]}
-        scheduleState={schedule}
-        setScheduleState={setSchedule}
+        schedule={schedule}
+        setSchedule={setSchedule}
         controlId="psd1"
       />,
     );

--- a/frontend/src/tests/components/PersonalSchedules/PersonalScheduleDropdown.test.js
+++ b/frontend/src/tests/components/PersonalSchedules/PersonalScheduleDropdown.test.js
@@ -37,8 +37,8 @@ describe("SingleSubjectDropdown tests", () => {
     render(
       <PersonalScheduleDropdown
         schedules={personalScheduleFixtures.onePersonalSchedule}
-        schedule={personalScheduleFixtures.onePersonalSchedule}
-        setSchedule={setSchedule}
+        scheduleState={personalScheduleFixtures.onePersonalSchedule}
+        setScheduleState={setSchedule}
         controlId="psd1"
       />,
     );
@@ -48,8 +48,8 @@ describe("SingleSubjectDropdown tests", () => {
     render(
       <PersonalScheduleDropdown
         schedules={personalScheduleFixtures.threePersonalSchedules}
-        schedule={schedule}
-        setSchedule={setSchedule}
+        scheduleState={schedule}
+        setscheduleState={setSchedule}
         controlId="psd2"
       />,
     );
@@ -59,8 +59,8 @@ describe("SingleSubjectDropdown tests", () => {
     render(
       <PersonalScheduleDropdown
         schedules={personalScheduleFixtures.threePersonalSchedules}
-        schedule={schedule}
-        setSchedule={setSchedule}
+        scheduleState={schedule}
+        setscheduleState={setSchedule}
         controlId="psd3"
       />,
     );
@@ -75,8 +75,8 @@ describe("SingleSubjectDropdown tests", () => {
     render(
       <PersonalScheduleDropdown
         schedules={personalScheduleFixtures.threePersonalSchedules}
-        schedule={schedule}
-        setSchedule={setSchedule}
+        scheduleState={schedule}
+        setScheduleState={setSchedule}
         controlId="psd1"
         onChange={onChange}
       />,
@@ -97,8 +97,8 @@ describe("SingleSubjectDropdown tests", () => {
     render(
       <PersonalScheduleDropdown
         schedules={personalScheduleFixtures.threePersonalSchedules}
-        schedule={schedule}
-        setSchedule={setSchedule}
+        scheduleState={schedule}
+        setScheduleState={setSchedule}
         controlId="psd1"
       />,
     );
@@ -110,8 +110,8 @@ describe("SingleSubjectDropdown tests", () => {
     render(
       <PersonalScheduleDropdown
         schedules={personalScheduleFixtures.threePersonalSchedules}
-        schedule={schedule}
-        setSchedule={setSchedule}
+        scheduleState={schedule}
+        setScheduleState={setSchedule}
         controlId="psd1"
       />,
     );
@@ -130,8 +130,8 @@ describe("SingleSubjectDropdown tests", () => {
     render(
       <PersonalScheduleDropdown
         schedules={personalScheduleFixtures.threePersonalSchedules}
-        schedule={schedule}
-        setSchedule={setSchedule}
+        scheduleState={schedule}
+        setScheduleState={setSchedule}
         controlId="psd1"
       />,
     );
@@ -149,8 +149,8 @@ describe("SingleSubjectDropdown tests", () => {
     render(
       <PersonalScheduleDropdown
         schedules={personalScheduleFixtures.threePersonalSchedules}
-        schedule={schedule}
-        setSchedule={setSchedule}
+        scheduleState={schedule}
+        setScheduleState={setSchedule}
         controlId="psd1"
       />,
     );
@@ -164,8 +164,8 @@ describe("SingleSubjectDropdown tests", () => {
     render(
       <PersonalScheduleDropdown
         schedules={[]}
-        schedule={schedule}
-        setSchedule={setSchedule}
+        scheduleState={schedule}
+        setScheduleState={setSchedule}
         controlId="psd1"
       />,
     );

--- a/frontend/src/tests/components/PersonalSchedules/PersonalSchedulesTable.test.js
+++ b/frontend/src/tests/components/PersonalSchedules/PersonalSchedulesTable.test.js
@@ -300,7 +300,7 @@ describe("UserTable tests", () => {
     expect(
       await screen.findByTestId(`PersonalSchedulesTable-cell-row-0-col-id`),
     ).toHaveTextContent("1");
-
+    localStorage.setItem("CourseForm-psId", "1");
     const deleteButton = screen.getByTestId(
       `PersonalSchedulesTable-cell-row-0-col-Delete-button`,
     );

--- a/frontend/src/tests/pages/Courses/CoursesCreatePage.test.js
+++ b/frontend/src/tests/pages/Courses/CoursesCreatePage.test.js
@@ -76,11 +76,12 @@ describe("CoursesCreatePage tests", () => {
 
     expect(await screen.findByTestId("CourseForm-psId")).toBeInTheDocument();
 
-    const psIdField = screen.getByTestId("CourseForm-psId");
+    const psIdField = document.querySelector("#CourseForm-psId");
     const enrollCdField = screen.getByTestId("CourseForm-enrollCd");
     const submitButton = screen.getByTestId("CourseForm-submit");
 
     fireEvent.change(psIdField, { target: { value: 13 } });
+    localStorage.setItem("CourseForm-psId", "13");
     fireEvent.change(enrollCdField, { target: { value: "08250" } });
 
     expect(submitButton).toBeInTheDocument();
@@ -91,7 +92,7 @@ describe("CoursesCreatePage tests", () => {
 
     // expect(quarterField).toHaveValue("20124");
     //expect(setQuarter).toBeCalledWith("20124"); //need this and axiosMock below?
-
+    expect(localStorage.getItem("CourseForm-psId")).toBe("13");
     expect(axiosMock.history.post[0].params).toEqual({
       psId: "13",
       enrollCd: "08250",
@@ -116,7 +117,7 @@ describe("CoursesCreatePage tests", () => {
 
     expect(await screen.findByTestId("CourseForm-psId")).toBeInTheDocument();
 
-    const psIdField = screen.getByTestId("CourseForm-psId");
+    const psIdField = document.querySelector("#CourseForm-psId");
     const enrollCdField = screen.getByTestId("CourseForm-enrollCd");
     const submitButton = screen.getByTestId("CourseForm-submit");
 


### PR DESCRIPTION
This commit replaces a textbox (prompt for Personal Schedule ID) with a dropdown to choose a Personal Schedule from a list with names when adding a Course to a Personal Schedule.

NOTE: There needs to be 2 schedules and the user has to click between them in the dropdown choice for it to work; it doesn't seem like other groups have found a workaround for this; apart from this Bug, the feature works as intended.

<img width="1401" alt="image" src="https://github.com/ucsb-cs156-f23/proj-courses-f23-7pm-1/assets/73411210/e791fb64-aa21-4328-a4aa-e76148899eaa">

Closes #8 