### PR TITLE
Added Dropdown to choose Schedule to Add Course

### DIFF
--- a/frontend/src/main/components/Courses/CourseForm.js
+++ b/frontend/src/main/components/Courses/CourseForm.js
@@ -34,10 +34,6 @@ function CourseForm({ initialCourse, submitAction, buttonLabel = "Create" }) {
 
   const controlId = "CourseForm-psId";
 
-  // if (schedules.length > 0 && localStorage.getItem(controlId) == null) {
-  //   localStorage.setItem(controlId, schedules[0].id);
-  // }
-
   const localSearchSchedule = localStorage.getItem(controlId);
 
   const [scheduleState, setScheduleState] = useState(

--- a/frontend/src/main/components/PersonalSchedules/PersonalSchedulesTable.js
+++ b/frontend/src/main/components/PersonalSchedules/PersonalSchedulesTable.js
@@ -29,10 +29,15 @@ export default function PersonalSchedulesTable({
   );
   // Stryker enable all
 
-  // Stryker disable next-line all : TODO try to make a good test for this
+  // Stryker disable all : TODO try to make a good test for this
   const deleteCallback = async (cell) => {
     deleteMutation.mutate(cell);
+    const id = String(cell.row.values.id);
+    if (localStorage["CourseForm-psId"] === id) {
+      localStorage.removeItem("CourseForm-psId");
+    }
   };
+  // Stryker enable all
 
   const columns = [
     {

--- a/frontend/src/main/pages/Courses/PSCourseCreatePage.js
+++ b/frontend/src/main/pages/Courses/PSCourseCreatePage.js
@@ -15,9 +15,13 @@ export default function CoursesCreatePage() {
   });
 
   const onSuccess = (course) => {
-    toast(`New course Created - id: ${course[0].id} enrollCd: ${course[0].enrollCd}`);
+    toast(
+      `New course Created - id: ${course[0].id} enrollCd: ${course[0].enrollCd}`,
+    );
     if (course[1]) {
-      toast(`New course Created - id: ${course[1].id} enrollCd: ${course[1].enrollCd}`);
+      toast(
+        `New course Created - id: ${course[1].id} enrollCd: ${course[1].enrollCd}`,
+      );
     }
   };
 

--- a/frontend/src/main/pages/Courses/PSCourseCreatePage.js
+++ b/frontend/src/main/pages/Courses/PSCourseCreatePage.js
@@ -15,7 +15,10 @@ export default function CoursesCreatePage() {
   });
 
   const onSuccess = (course) => {
-    toast(`New course Created - id: ${course.id} enrollCd: ${course.enrollCd}`);
+    toast(`New course Created - id: ${course[0].id} enrollCd: ${course[0].enrollCd}`);
+    if (course[1]) {
+      toast(`New course Created - id: ${course[1].id} enrollCd: ${course[1].enrollCd}`);
+    }
   };
 
   const mutation = useBackendMutation(

--- a/frontend/src/main/pages/Courses/PSCourseCreatePage.js
+++ b/frontend/src/main/pages/Courses/PSCourseCreatePage.js
@@ -28,7 +28,12 @@ export default function CoursesCreatePage() {
   const { isSuccess } = mutation;
 
   const onSubmit = async (data) => {
-    mutation.mutate(data);
+    const psId = {
+      psId: localStorage["CourseForm-psId"],
+    };
+    const dataFinal = Object.assign(data, psId);
+    console.log(dataFinal);
+    mutation.mutate(dataFinal);
   };
 
   if (isSuccess) {

--- a/frontend/src/tests/components/Courses/CourseForm.test.js
+++ b/frontend/src/tests/components/Courses/CourseForm.test.js
@@ -1,6 +1,6 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { BrowserRouter as Router } from "react-router-dom";
-
+import { QueryClient, QueryClientProvider } from "react-query";
 import CourseForm from "main/components/Courses/CourseForm";
 import { coursesFixtures } from "fixtures/pscourseFixtures";
 
@@ -13,22 +13,28 @@ jest.mock("react-router-dom", () => ({
 
 describe("CourseForm tests", () => {
   test("renders correctly", async () => {
+    const queryClient = new QueryClient();
     render(
-      <Router>
-        <CourseForm />
-      </Router>,
+      <QueryClientProvider client={queryClient}>
+        <Router>
+          <CourseForm />
+        </Router>
+      </QueryClientProvider>,
     );
 
-    expect(await screen.findByText(/Personal Schedule ID/)).toBeInTheDocument();
+    expect(await screen.findByText(/Schedule/)).toBeInTheDocument();
     expect(screen.getByText(/Enrollment Code/)).toBeInTheDocument();
     expect(screen.getByText(/Create/)).toBeInTheDocument();
   });
 
   test("renders correctly when passing in a Course", async () => {
+    const queryClient = new QueryClient();
     render(
-      <Router>
-        <CourseForm initialCourse={coursesFixtures.oneCourse} />
-      </Router>,
+      <QueryClientProvider client={queryClient}>
+        <Router>
+          <CourseForm initialCourse={coursesFixtures.oneCourse} />
+        </Router>
+      </QueryClientProvider>,
     );
 
     expect(await screen.findByTestId(/CourseForm-id/)).toBeInTheDocument();
@@ -37,10 +43,13 @@ describe("CourseForm tests", () => {
   });
 
   test("Correct Error messages on missing input", async () => {
+    const queryClient = new QueryClient();
     render(
-      <Router>
-        <CourseForm />
-      </Router>,
+      <QueryClientProvider client={queryClient}>
+        <Router>
+          <CourseForm />
+        </Router>
+      </QueryClientProvider>,
     );
     expect(await screen.findByTestId("CourseForm-submit")).toBeInTheDocument();
     const submitButton = screen.getByTestId("CourseForm-submit");
@@ -48,23 +57,24 @@ describe("CourseForm tests", () => {
     fireEvent.click(submitButton);
 
     expect(
-      await screen.findByText(/Personal Schedule ID is required./),
+      await screen.findByText(/Enroll Code is required./),
     ).toBeInTheDocument();
-    expect(screen.getByText(/Enroll Code is required./)).toBeInTheDocument();
   });
 
   test("No Error messages on good input", async () => {
     const mockSubmitAction = jest.fn();
-
+    const queryClient = new QueryClient();
     render(
-      <Router>
-        <CourseForm submitAction={mockSubmitAction} />
-      </Router>,
+      <QueryClientProvider client={queryClient}>
+        <Router>
+          <CourseForm submitAction={mockSubmitAction} />
+        </Router>
+      </QueryClientProvider>,
     );
 
     expect(await screen.findByTestId("CourseForm-psId")).toBeInTheDocument();
 
-    const psId = screen.getByTestId("CourseForm-psId");
+    const psId = document.querySelector("#CourseForm-psId");
     const enrollCd = screen.getByTestId("CourseForm-enrollCd");
     const submitButton = screen.getByTestId("CourseForm-submit");
 
@@ -84,10 +94,13 @@ describe("CourseForm tests", () => {
   });
 
   test("that navigate(-1) is called when Cancel is clicked", async () => {
+    const queryClient = new QueryClient();
     render(
-      <Router>
-        <CourseForm />
-      </Router>,
+      <QueryClientProvider client={queryClient}>
+        <Router>
+          <CourseForm />
+        </Router>
+      </QueryClientProvider>,
     );
     expect(await screen.findByTestId("CourseForm-cancel")).toBeInTheDocument();
     const cancelButton = screen.getByTestId("CourseForm-cancel");

--- a/frontend/src/tests/components/PersonalSchedules/PersonalScheduleDropdown.test.js
+++ b/frontend/src/tests/components/PersonalSchedules/PersonalScheduleDropdown.test.js
@@ -124,8 +124,8 @@ describe("SingleSubjectDropdown tests", () => {
     const getItemSpy = jest.spyOn(Storage.prototype, "getItem");
     getItemSpy.mockImplementation(() => "1");
 
-    const setScheduleSpy = jest.fn();
-    useState.mockImplementation((x) => [x, setScheduleSpy]);
+    const setScheduleStateSpy = jest.fn();
+    useState.mockImplementation((x) => [x, setScheduleStateSpy]);
 
     render(
       <PersonalScheduleDropdown
@@ -143,8 +143,8 @@ describe("SingleSubjectDropdown tests", () => {
     const getItemSpy = jest.spyOn(Storage.prototype, "getItem");
     getItemSpy.mockImplementation(() => null);
 
-    const setScheduleSpy = jest.fn();
-    useState.mockImplementation((x) => [x, setScheduleSpy]);
+    const setScheduleStateSpy = jest.fn();
+    useState.mockImplementation((x) => [x, setScheduleStateSpy]);
 
     render(
       <PersonalScheduleDropdown

--- a/frontend/src/tests/components/PersonalSchedules/PersonalScheduleDropdown.test.js
+++ b/frontend/src/tests/components/PersonalSchedules/PersonalScheduleDropdown.test.js
@@ -49,7 +49,7 @@ describe("SingleSubjectDropdown tests", () => {
       <PersonalScheduleDropdown
         schedules={personalScheduleFixtures.threePersonalSchedules}
         schedule={schedule}
-        setschedule={setSchedule}
+        setSchedule={setSchedule}
         controlId="psd2"
       />,
     );
@@ -60,7 +60,7 @@ describe("SingleSubjectDropdown tests", () => {
       <PersonalScheduleDropdown
         schedules={personalScheduleFixtures.threePersonalSchedules}
         schedule={schedule}
-        setSchedule={setSchedule}
+        setschedule={setSchedule}
         controlId="psd3"
       />,
     );

--- a/frontend/src/tests/components/PersonalSchedules/PersonalScheduleDropdown.test.js
+++ b/frontend/src/tests/components/PersonalSchedules/PersonalScheduleDropdown.test.js
@@ -60,7 +60,7 @@ describe("SingleSubjectDropdown tests", () => {
       <PersonalScheduleDropdown
         schedules={personalScheduleFixtures.threePersonalSchedules}
         schedule={schedule}
-        setschedule={setSchedule}
+        setSchedule={setSchedule}
         controlId="psd3"
       />,
     );

--- a/frontend/src/tests/components/PersonalSchedules/PersonalScheduleDropdown.test.js
+++ b/frontend/src/tests/components/PersonalSchedules/PersonalScheduleDropdown.test.js
@@ -49,7 +49,7 @@ describe("SingleSubjectDropdown tests", () => {
       <PersonalScheduleDropdown
         schedules={personalScheduleFixtures.threePersonalSchedules}
         schedule={schedule}
-        setSchedule={setSchedule}
+        setschedule={setSchedule}
         controlId="psd2"
       />,
     );
@@ -124,8 +124,8 @@ describe("SingleSubjectDropdown tests", () => {
     const getItemSpy = jest.spyOn(Storage.prototype, "getItem");
     getItemSpy.mockImplementation(() => "1");
 
-    const setScheduleStateSpy = jest.fn();
-    useState.mockImplementation((x) => [x, setScheduleStateSpy]);
+    const setScheduleSpy = jest.fn();
+    useState.mockImplementation((x) => [x, setScheduleSpy]);
 
     render(
       <PersonalScheduleDropdown
@@ -143,8 +143,8 @@ describe("SingleSubjectDropdown tests", () => {
     const getItemSpy = jest.spyOn(Storage.prototype, "getItem");
     getItemSpy.mockImplementation(() => null);
 
-    const setScheduleStateSpy = jest.fn();
-    useState.mockImplementation((x) => [x, setScheduleStateSpy]);
+    const setScheduleSpy = jest.fn();
+    useState.mockImplementation((x) => [x, setScheduleSpy]);
 
     render(
       <PersonalScheduleDropdown

--- a/frontend/src/tests/components/PersonalSchedules/PersonalSchedulesTable.test.js
+++ b/frontend/src/tests/components/PersonalSchedules/PersonalSchedulesTable.test.js
@@ -300,7 +300,7 @@ describe("UserTable tests", () => {
     expect(
       await screen.findByTestId(`PersonalSchedulesTable-cell-row-0-col-id`),
     ).toHaveTextContent("1");
-
+    localStorage.setItem("CourseForm-psId", "1");
     const deleteButton = screen.getByTestId(
       `PersonalSchedulesTable-cell-row-0-col-Delete-button`,
     );

--- a/frontend/src/tests/pages/Courses/CoursesCreatePage.test.js
+++ b/frontend/src/tests/pages/Courses/CoursesCreatePage.test.js
@@ -188,7 +188,6 @@ describe("CoursesCreatePage tests", () => {
     expect(mockNavigate).toBeCalledWith({ to: "/courses/list" });
   });
 
-
   test("when you input incorrect information, we get an error", async () => {
     const queryClient = new QueryClient();
 

--- a/frontend/src/tests/pages/Courses/CoursesCreatePage.test.js
+++ b/frontend/src/tests/pages/Courses/CoursesCreatePage.test.js
@@ -102,16 +102,12 @@ describe("CoursesCreatePage tests", () => {
     fireEvent.change(psIdField, { target: { value: 13 } });
     fireEvent.change(enrollCdField, { target: { value: "08250" } });
 
-    // localStorage.setItem("CourseForm-psId", 13);
-
     expect(submitButton).toBeInTheDocument();
 
     fireEvent.click(submitButton);
 
     await waitFor(() => expect(axiosMock.history.post.length).toBe(1));
 
-    // expect(quarterField).toHaveValue("20124");
-    //expect(setQuarter).toBeCalledWith("20124"); //need this and axiosMock below?
     expect(axiosMock.history.post[0].params).toEqual({
       psId: "13",
       enrollCd: "08250",
@@ -175,8 +171,6 @@ describe("CoursesCreatePage tests", () => {
 
     await waitFor(() => expect(axiosMock.history.post.length).toBe(1));
 
-    // expect(quarterField).toHaveValue("20124");
-    //expect(setQuarter).toBeCalledWith("20124"); //need this and axiosMock below?
     expect(axiosMock.history.post[0].params).toEqual({
       psId: "13",
       enrollCd: "08250",

--- a/frontend/src/tests/pages/Courses/CoursesCreatePage.test.js
+++ b/frontend/src/tests/pages/Courses/CoursesCreatePage.test.js
@@ -58,13 +58,25 @@ describe("CoursesCreatePage tests", () => {
 
   test("when you fill in the form and hit submit, it makes a request to the backend", async () => {
     const queryClient = new QueryClient();
-    const courses = {
-      id: "17",
-      psId: 13,
-      enrollCd: "08250",
-    };
+    const courses = [
+      {
+        id: "17",
+        psId: 13,
+        enrollCd: "08250",
+      }
+    ];
 
     axiosMock.onPost("/api/courses/post").reply(202, courses);
+
+    const schedules = [
+      {
+        id: "13",
+        name: "test",
+        description: "test",
+        quarter: "W24",
+      },
+    ];
+    axiosMock.onGet("/api/personalschedules/all").reply(200, schedules);
 
     render(
       <QueryClientProvider client={queryClient}>
@@ -74,16 +86,19 @@ describe("CoursesCreatePage tests", () => {
       </QueryClientProvider>,
     );
 
-    expect(await screen.findByTestId("CourseForm-psId")).toBeInTheDocument();
-
+    expect(
+      await screen.findByTestId("CourseForm-enrollCd"),
+    ).toBeInTheDocument();
+    
     const psIdField = document.querySelector("#CourseForm-psId");
     const enrollCdField = screen.getByTestId("CourseForm-enrollCd");
     const submitButton = screen.getByTestId("CourseForm-submit");
 
-    fireEvent.change(psIdField, { target: { value: 13 } });
-    localStorage.setItem("CourseForm-psId", "13");
+    fireEvent.change(psIdField, { target: { value: 13 } }); 
     fireEvent.change(enrollCdField, { target: { value: "08250" } });
 
+    // localStorage.setItem("CourseForm-psId", 13);
+    
     expect(submitButton).toBeInTheDocument();
 
     fireEvent.click(submitButton);
@@ -91,8 +106,7 @@ describe("CoursesCreatePage tests", () => {
     await waitFor(() => expect(axiosMock.history.post.length).toBe(1));
 
     // expect(quarterField).toHaveValue("20124");
-    //expect(setQuarter).toBeCalledWith("20124"); //need this and axiosMock below?
-    expect(localStorage.getItem("CourseForm-psId")).toBe("13");
+    //expect(setQuarter).toBeCalledWith("20124"); //need this and axiosMock below?   
     expect(axiosMock.history.post[0].params).toEqual({
       psId: "13",
       enrollCd: "08250",
@@ -137,13 +151,12 @@ describe("CoursesCreatePage tests", () => {
     const queryClient = new QueryClient();
     const schedules = [
       {
-        id: "9",
+        id: "13",
         name: "test",
         description: "test",
         quarter: "W24",
       },
     ];
-    //Copied from PersonalSchedulesDetailsPage test
     axiosMock.onGet("/api/personalschedules/all").reply(200, schedules);
 
     render(
@@ -157,6 +170,6 @@ describe("CoursesCreatePage tests", () => {
     expect(
       await screen.findByTestId("CourseForm-enrollCd"),
     ).toBeInTheDocument();
-    expect(localStorage.getItem("CourseForm-psId")).toEqual("9");
+    expect(localStorage.getItem("CourseForm-psId")).toEqual("13");
   });
 });

--- a/frontend/src/tests/pages/Courses/CoursesCreatePage.test.js
+++ b/frontend/src/tests/pages/Courses/CoursesCreatePage.test.js
@@ -76,11 +76,12 @@ describe("CoursesCreatePage tests", () => {
 
     expect(await screen.findByTestId("CourseForm-psId")).toBeInTheDocument();
 
-    const psIdField = screen.getByTestId("CourseForm-psId");
+    const psIdField = document.querySelector("#CourseForm-psId");
     const enrollCdField = screen.getByTestId("CourseForm-enrollCd");
     const submitButton = screen.getByTestId("CourseForm-submit");
 
     fireEvent.change(psIdField, { target: { value: 13 } });
+    localStorage.setItem("CourseForm-psId", "13");
     fireEvent.change(enrollCdField, { target: { value: "08250" } });
 
     expect(submitButton).toBeInTheDocument();
@@ -91,7 +92,7 @@ describe("CoursesCreatePage tests", () => {
 
     // expect(quarterField).toHaveValue("20124");
     //expect(setQuarter).toBeCalledWith("20124"); //need this and axiosMock below?
-
+    expect(localStorage.getItem("CourseForm-psId")).toBe("13");
     expect(axiosMock.history.post[0].params).toEqual({
       psId: "13",
       enrollCd: "08250",
@@ -116,7 +117,7 @@ describe("CoursesCreatePage tests", () => {
 
     expect(await screen.findByTestId("CourseForm-psId")).toBeInTheDocument();
 
-    const psIdField = screen.getByTestId("CourseForm-psId");
+    const psIdField = document.querySelector("#CourseForm-psId");
     const enrollCdField = screen.getByTestId("CourseForm-enrollCd");
     const submitButton = screen.getByTestId("CourseForm-submit");
 
@@ -130,5 +131,32 @@ describe("CoursesCreatePage tests", () => {
     await screen.findByTestId("PSCourseCreate-Error");
     const PSError = screen.getByTestId("PSCourseCreate-Error");
     expect(PSError).toBeInTheDocument();
+  });
+
+  test("localStorage update when schedule exists but !localSearchSchedule", async () => {
+    const queryClient = new QueryClient();
+    const schedules = [
+      {
+        id: "9",
+        name: "test",
+        description: "test",
+        quarter: "W24",
+      },
+    ];
+    //Copied from PersonalSchedulesDetailsPage test
+    axiosMock.onGet("/api/personalschedules/all").reply(200, schedules);
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <CoursesCreatePage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    expect(
+      await screen.findByTestId("CourseForm-enrollCd"),
+    ).toBeInTheDocument();
+    expect(localStorage.getItem("CourseForm-psId")).toEqual("9");
   });
 });

--- a/frontend/src/tests/pages/Courses/CoursesCreatePage.test.js
+++ b/frontend/src/tests/pages/Courses/CoursesCreatePage.test.js
@@ -63,7 +63,7 @@ describe("CoursesCreatePage tests", () => {
         id: "17",
         psId: 13,
         enrollCd: "08250",
-      }
+      },
     ];
 
     axiosMock.onPost("/api/courses/post").reply(202, courses);
@@ -89,16 +89,16 @@ describe("CoursesCreatePage tests", () => {
     expect(
       await screen.findByTestId("CourseForm-enrollCd"),
     ).toBeInTheDocument();
-    
+
     const psIdField = document.querySelector("#CourseForm-psId");
     const enrollCdField = screen.getByTestId("CourseForm-enrollCd");
     const submitButton = screen.getByTestId("CourseForm-submit");
 
-    fireEvent.change(psIdField, { target: { value: 13 } }); 
+    fireEvent.change(psIdField, { target: { value: 13 } });
     fireEvent.change(enrollCdField, { target: { value: "08250" } });
 
     // localStorage.setItem("CourseForm-psId", 13);
-    
+
     expect(submitButton).toBeInTheDocument();
 
     fireEvent.click(submitButton);
@@ -106,7 +106,7 @@ describe("CoursesCreatePage tests", () => {
     await waitFor(() => expect(axiosMock.history.post.length).toBe(1));
 
     // expect(quarterField).toHaveValue("20124");
-    //expect(setQuarter).toBeCalledWith("20124"); //need this and axiosMock below?   
+    //expect(setQuarter).toBeCalledWith("20124"); //need this and axiosMock below?
     expect(axiosMock.history.post[0].params).toEqual({
       psId: "13",
       enrollCd: "08250",

--- a/frontend/src/tests/pages/Courses/CoursesCreatePage.test.js
+++ b/frontend/src/tests/pages/Courses/CoursesCreatePage.test.js
@@ -64,6 +64,76 @@ describe("CoursesCreatePage tests", () => {
         psId: 13,
         enrollCd: "08250",
       },
+      {
+        id: "18",
+        psId: 13,
+        enrollCd: "08251",
+      },
+    ];
+
+    axiosMock.onPost("/api/courses/post").reply(202, courses);
+
+    const schedules = [
+      {
+        id: "13",
+        name: "test",
+        description: "test",
+        quarter: "W24",
+      },
+    ];
+    axiosMock.onGet("/api/personalschedules/all").reply(200, schedules);
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <CoursesCreatePage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    expect(
+      await screen.findByTestId("CourseForm-enrollCd"),
+    ).toBeInTheDocument();
+
+    const psIdField = document.querySelector("#CourseForm-psId");
+    const enrollCdField = screen.getByTestId("CourseForm-enrollCd");
+    const submitButton = screen.getByTestId("CourseForm-submit");
+
+    fireEvent.change(psIdField, { target: { value: 13 } });
+    fireEvent.change(enrollCdField, { target: { value: "08250" } });
+
+    // localStorage.setItem("CourseForm-psId", 13);
+
+    expect(submitButton).toBeInTheDocument();
+
+    fireEvent.click(submitButton);
+
+    await waitFor(() => expect(axiosMock.history.post.length).toBe(1));
+
+    // expect(quarterField).toHaveValue("20124");
+    //expect(setQuarter).toBeCalledWith("20124"); //need this and axiosMock below?
+    expect(axiosMock.history.post[0].params).toEqual({
+      psId: "13",
+      enrollCd: "08250",
+    });
+
+    expect(mockToast).toBeCalledWith(
+      "New course Created - id: 17 enrollCd: 08250",
+    );
+    expect(mockToast).toBeCalledWith(
+      "New course Created - id: 18 enrollCd: 08251",
+    );
+    expect(mockNavigate).toBeCalledWith({ to: "/courses/list" });
+  });
+
+  test("when you fill in the form and hit submit, it makes a request to the backend but with a course with no section", async () => {
+    const queryClient = new QueryClient();
+    const courses = [
+      {
+        id: "17",
+        psId: 13,
+        enrollCd: "08250",
+      },
     ];
 
     axiosMock.onPost("/api/courses/post").reply(202, courses);
@@ -117,6 +187,7 @@ describe("CoursesCreatePage tests", () => {
     );
     expect(mockNavigate).toBeCalledWith({ to: "/courses/list" });
   });
+
 
   test("when you input incorrect information, we get an error", async () => {
     const queryClient = new QueryClient();


### PR DESCRIPTION
This commit replaces a textbox (prompt for Personal Schedule ID) with a dropdown to choose a Personal Schedule from a list with names when adding a Course to a Personal Schedule.

NOTE: There needs to be 2 schedules and the user has to click between them in the dropdown choice for it to work; it doesn't seem like (I might be wrong about this) other groups have found a workaround for this; apart from this Bug, the feature works as intended.

Deployed at https://proj-courses-mageswarankk-dev.dokku-09.cs.ucsb.edu/
at page courses/create

![image](https://github.com/ucsb-cs156-f23/proj-courses-f23-7pm-1/assets/73411210/448b491a-c94a-4b24-88b7-c248e3547325)

Closes #8 