### PR TITLE
(Not for points) Removed "Is Section?" column from main Section Table

### DIFF
--- a/frontend/src/main/components/SectionsTableBase.js
+++ b/frontend/src/main/components/SectionsTableBase.js
@@ -14,7 +14,7 @@ export default function SectionsTableBase({
       {
         initialState: {
           groupBy: ["courseInfo.courseId"],
-          hiddenColumns: [],
+          hiddenColumns: ["isSection"],
         },
         columns,
         data,


### PR DESCRIPTION
Closes #40 

In a previously approved and merged PR (#33), the "Is Section?" column was accidentally unmarked as hidden, showing a blank value for all entries in the Section Table. In this PR, we fix this bug.

The change is available at https://proj-courses-irreflexive-dev.dokku-09.cs.ucsb.edu/. Note that there is no longer an "Is Section?" column header with blank values for each course/section.
![image](https://github.com/ucsb-cs156-f23/proj-courses-f23-7pm-1/assets/33270232/8dab3a90-15f7-4520-979a-8516665db3ec)