### PR TITLE
pc - add debugging output steps to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,8 @@ COPY lombok.config /home/app
 COPY pom.xml /home/app
 
 ENV PRODUCTION=true
+RUN pwd
+RUN ls -lRt
 RUN mvn -B -DskipTests -Pproduction -f /home/app/pom.xml clean package
 
 ENTRYPOINT ["sh", "-c", "java -jar /home/app/target/*.jar"]


### PR DESCRIPTION
In this draft PR, we try to debug why the git info plugin isn't working properly on dokku.